### PR TITLE
Add janrain form to web2py register page

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -31,6 +31,10 @@ def user():
         # Recreate the form with the temporarily updated default course_id
         form = auth.register()
 
+        # add the Janrain login form
+        form[0][5][2] = ''
+        form.insert(0, DIV(request.janrain_form.login_form(), _id='janrain-form'))
+
     if 'profile' in request.args(0):
         form.vars.course_id = auth.user.course_name
         if form.process().accepted:

--- a/models/db.py
+++ b/models/db.py
@@ -162,6 +162,8 @@ janrain_form = RPXAccount(request,
 auth.settings.login_form = ExtendedLoginForm(auth, janrain_form) # uncomment this to use both Janrain and web2py auth
 #auth.settings.login_form = auth # uncomment this to just use web2py integrated authentication
 
+request.janrain_form = janrain_form # save the form so that it can be added to the user/register controller
+
 #########################################################################
 ## Define your tables below (or better in another model file) for example
 ##

--- a/static/plugin_layouts/sphinx_bootstrap/static/runestone-custom-sphinx-bootstrap.css
+++ b/static/plugin_layouts/sphinx_bootstrap/static/runestone-custom-sphinx-bootstrap.css
@@ -200,3 +200,9 @@ div.flash {
     border-radius: 4px;
     text-shadow: 0 1px 0 rgba(255,255,255,0.5);
 }
+
+#janrain-form {
+    float: right;
+    margin-left: 100px;
+    margin-top: -12px;
+}

--- a/static/runestone-custom-sphinx-bootstrap.css
+++ b/static/runestone-custom-sphinx-bootstrap.css
@@ -191,3 +191,18 @@ div.flash {
     padding-bottom: 13px;
 }
 
+.assess-feedback {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    padding: 7px;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+    text-shadow: 0 1px 0 rgba(255,255,255,0.5);
+}
+
+#janrain-form {
+    float: right;
+    margin-left: 100px;
+    margin-top: -12px;
+}


### PR DESCRIPTION
I added the Janrain login/register form to the web2py registration controller. 

Prior to this, if a user clicked the Register button from the navbar menu, they were taken to the web2py registration controller and never given the option to use a social connector to authenticate instead of local web2py registration.
