### PR TITLE
automatically create the instructor group if it doesn't already exist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,12 +138,11 @@ To use the admin functionalities you are going to want to do one more bit of con
 * Click the "Register" link in the upper right corner of the browser window.
 * Fill in the form to create a user account for yourself.
 
-Now, create an 'instructors' user group and add your new user account to it using the appadmin 
+Now, add your new user account to the 'instructors' group using the appadmin
 functionality of web2py:
 
 * Open ``http://127.0.0.1:8000/runestone/appadmin``. Login using the password you supplied when you ran web2py.
-* Click the link for ``insert new auth_group`` and add ``instructor`` as a role. Description can be whatever you want.
-* Go back to the appadmin/index page and click on ``insert new auth_membership``. Select your user account and the new instructor group as the two values and click submit.  You are now an instructor.
+* Click on ``insert new auth_membership``. Select your user account and the instructor group as the two values and click submit.  You are now an instructor.
 
 
 How to Contribute

--- a/models/db.py
+++ b/models/db.py
@@ -133,6 +133,9 @@ db.auth_user.course_id.requires = IS_COURSE_ID()
 
 auth.define_tables(migrate=settings.migrate)
 
+# create the instructor group if it doesn't already exist
+if not db(db.auth_group.role == 'instructor').select().first():
+    db.auth_group.insert(role='instructor')
 
 ## configure email
 mail=auth.settings.mailer


### PR DESCRIPTION
Fixes #234.

This is a really minor issue that only really affects running runestone locally. It avoids having to have some more error handling in the controller for new course creation.
