### PR TITLE
Fix Parsons drag/drop issue

### DIFF
--- a/static/runestone-custom-sphinx-bootstrap.css
+++ b/static/runestone-custom-sphinx-bootstrap.css
@@ -335,3 +335,8 @@ div.flash {
     background-position: center;
     background-repeat: no-repeat;
 }
+
+.ui-sortable-helper {
+    height: auto !important;
+    width: auto !important;
+}


### PR DESCRIPTION
I couldn't figure out where in the Parsons code the element height was being set, so I sort of took the blunt hammer approach and overrode those styles.

It seems to be working correctly with these changes.

Fixes #289.
