### PR TITLE
switch to local serving of .js and .css files, rather than from runeston...

### DIFF
--- a/source/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/source/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -1,18 +1,18 @@
 {% extends "basic/layout.html" %}
 
 {% set script_files = script_files + [
-    'http://runestonestatic.appspot.com/static/'+build_info+'/jquery-ui-1.10.3.custom.min.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/jquery-fix.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/bootstrap-3.0.0/js/bootstrap.min.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/bootstrap-sphinx.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/waypoints.min.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/rangy-core.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/rangy-textrange.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/rangy-cssclassapplier.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/user-highlights.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/jquery.idle-timer.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/processing-1.4.1.min.js',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/jquery.hotkey.js'
+    '_static'+'/jquery-ui-1.10.3.custom.min.js',
+    '_static'+'/jquery-fix.js',
+    '_static'+'/bootstrap-3.0.0/js/bootstrap.min.js',
+    '_static'+'/bootstrap-sphinx.js',
+    '_static'+'/waypoints.min.js',
+    '_static'+'/rangy-core.js',
+    '_static'+'/rangy-textrange.js',
+    '_static'+'/rangy-cssclassapplier.js',
+    '_static'+'/user-highlights.js',
+    '_static'+'/jquery.idle-timer.js',
+    '_static'+'/processing-1.4.1.min.js',
+    '_static'+'/jquery.hotkey.js'
   ]
 %}
 
@@ -24,9 +24,9 @@
 {% endif %}
 
 {% set css_files = css_files + [
-    'http://runestonestatic.appspot.com/static/'+build_info+'/jquery-ui-1.10.3.custom.min.css',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/bootstrap-sphinx.css',
-    'http://runestonestatic.appspot.com/static/'+build_info+'/user-highlights.css',
+    '_static'+'/jquery-ui-1.10.3.custom.min.css',
+    '_static'+'/bootstrap-sphinx.css',
+    '_static'+'/user-highlights.css',
     '../runestone-custom-sphinx-bootstrap.css',
   ]
 %}


### PR DESCRIPTION
...estatic.appspot.com.

I needed to make this change in order to make my site work correctly when accessed via https. An alternative, if you want to host these .js files centrally, is to switch them to https.  Probably there should be a configuration parameter somewhere instead of hardcoding all of these.
