### PR TITLE
Fixed divide by 0 error for viewing group schedule

### DIFF
--- a/controllers/mygroup.py
+++ b/controllers/mygroup.py
@@ -52,8 +52,9 @@ def schedule():
                         if progress.user_sub_chapter_progress.status > 0:
                             count += 1
                         total += 1
-                result = round(count*100/total)
-                db((db.user_chapter_progress.user_id==user.id) & (db.user_chapter_progress.chapter_id==plan.chapters.id)).update(status=result)
+                if total > 0:
+                    result = round(count*100/total)
+                    db((db.user_chapter_progress.user_id==user.id) & (db.user_chapter_progress.chapter_id==plan.chapters.id)).update(status=result)
 
             userProgress = db(db.user_chapter_progress.chapter_id==plan.chapters.id).select(db.user_chapter_progress.status)
             completed = True


### PR DESCRIPTION
Added an if total > 0: line to keep the server from crashing with a divide by zero error due to the user having no user chapter progress.  This occurs when a user has yet to view any of the chapters of the book and attempts to access the group schedule.  Since the user's chapter progress will not exist, total will remain 0, causing this to break when it tries to calculate result by dividing by total, which will remain 0.
