### PR TITLE
Error in prim's spanning tree algorithm listing

### DIFF
--- a/pythonds/source/Graphs/PrimsSpanningTreeAlgorithm.rst
+++ b/pythonds/source/Graphs/PrimsSpanningTreeAlgorithm.rst
@@ -119,8 +119,7 @@ to the growing graph.
         while not pq.isEmpty():
             currentVert = pq.delMin()
             for nextVert in currentVert.getConnections():
-              newCost = currentVert.getWeight(nextVert) \
-                      + currentVert.getDistance()
+              newCost = currentVert.getWeight(nextVert)
               if nextVert in pq and newCost<nextVert.getDistance():
                   nextVert.setPred(currentVert)
                   nextVert.setDistance(newCost)


### PR DESCRIPTION
Look's like code for Prim's spanning tree algorithm is not correct.
Simple test. Check out this graph:

```
        A
       / \
    5 /   \ 9
     /     \
    B ----- C
        5
```

Correct minimum spanning tree must be (from node A):

```
        A
       /
    5 /
     /
    B ----- C
        5
```

whereas code from listing will produce following tree (same as dijkstra algorithm):

```
        A
       / \
    5 /   \ 9
     /     \
    B       C
```
