### PR TITLE
killing off the toc special case

### DIFF
--- a/models/scheduler.py
+++ b/models/scheduler.py
@@ -60,9 +60,6 @@ def run_sphinx(rvars=None, folder=None, application=None, http_host=None, base_c
             shutil.copy(path.join(confdir, 'assignments.rst'),
                         path.join(sourcedir, '_sources', 'assignments.rst'))
 
-            if os.path.exists(path.join(confdir, 'toc.rst')):
-                shutil.copy(path.join(confdir, 'toc.rst'),
-                            path.join(sourcedir, '_sources', 'toc.rst'))
 
         except OSError:
             # Either the sourcedir already exists (meaning this is probably devcourse, thinkcspy, etc,
@@ -76,8 +73,6 @@ def run_sphinx(rvars=None, folder=None, application=None, http_host=None, base_c
         # Save copies of files that the instructor may customize
         shutil.copy(path.join(sourcedir,'_sources', 'index.rst'),custom_dir)
         shutil.copy(path.join(sourcedir,'_sources', 'assignments.rst'),custom_dir)
-        if os.path.exists(path.join(sourcedir,'_sources', 'toc.rst')):
-            shutil.copy(path.join(sourcedir,'_sources', 'toc.rst'),custom_dir)
 
 
     ###########
@@ -92,10 +87,6 @@ def run_sphinx(rvars=None, folder=None, application=None, http_host=None, base_c
     except IOError as copyfail:
         logging.debug("Failed to copy build_info_file")
         logging.debug(copyfail.message)
-
-    if base_course == 'thinkcspy' or base_course == 'pip2':
-        idxname = 'toc.rst'
-    else:
         idxname = 'index.rst'
 
     #

--- a/views/admin/index.html
+++ b/views/admin/index.html
@@ -57,7 +57,6 @@
 	  <a href="/{{=request.application}}/admin/sections_create">Add a section</a>
 	</li>
     <li><a href="/{{=request.application}}/admin/editcustom/assignments">Edit my assignments page</a></li>
-    <li><a href="/{{=request.application}}/admin/editcustom/toc">Customize Chapter Order (thinkcspy only)</a> If you have a course created before July 21 2015 and want this feature contact me.</li>
     <li><a href="/{{=request.application}}/admin/editcustom/index">Customize Title Page and Order (all others)</a></li>
 	<li>
 	  <a href="/{{=request.application}}/admin/rebuildcourse">Rebuild my course</a>


### PR DESCRIPTION
only pip and thinkcspy have special splash pages with the table of contents moved to toc.rst  This changes the build process to be consistent for all books.  This also requires the pull request in thinkcspy (and @presnick should make a change to pip as well).