### PR TITLE
Github API  Bug Reports

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -264,22 +264,12 @@ def removecourse():
     redirect('/%s/default/courses' % request.application)
 
 def reportabug():
-    referer = request.META.get('HTTP_REFERER')
-    print(referer)
     return dict()
 
 def sendreport():
-    print(request.vars['bookerror'])
-    for key in request.vars:
-        print(key)
-        print('key maps to', request.vars[key])
-
-    #these values should be changed to the credentials of a Github account in order for the bug reports to be sent.
-    access_token = 'f4343a5620d93a4cabac6a2950d217c2e17c2a9f'
-    USERNAME = 'USERNAME'
-    PASSWORD = 'PASSWORD'
+    #this value should be changed to a valid Github access token that has full repo access
+    access_token = 'TOKENSTRING'
     if request.vars['bookerror'] == 'on':
-        print('checkbox not checked')
         basecourse = db(db.courses.course_name == request.vars['coursename']).select().first().base_course
         if basecourse == None:
             url = 'https://api.github.com/repos/RunestoneInteractive/%s/issues' % request.vars['coursename']
@@ -288,7 +278,6 @@ def sendreport():
     else:
         url = 'https://api.github.com/repos/RunestoneInteractive/RunestoneComponents/issues'
     reqsession = requests.Session()
-    #reqsession.auth = (USERNAME, PASSWORD)
     reqsession.auth = ('token', access_token)
     body = 'Error reported in course ' + request.vars['coursename'] + ' on page ' + request.vars['pagename'] + '\n' + request.vars['bugdetails']
     issue = {'title': request.vars['bugtitle'],
@@ -298,8 +287,5 @@ def sendreport():
         session.flash = 'Successfully created Issue "%s"' % request.vars['bugtitle']
     else:
         session.flash = 'Could not create Issue "%s"' % request.vars['bugtitle']
-        print('Response:', r.content)
-
-    print(r.status_code)
 
     redirect('/%s/default/reportabug' % request.application)

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 ### required - do not delete
+import cgi
 import json
+import os
 import requests
 from urllib import unquote
 
@@ -262,6 +264,8 @@ def removecourse():
     redirect('/%s/default/courses' % request.application)
 
 def reportabug():
+    referer = request.META.get('HTTP_REFERER')
+    print(referer)
     return dict()
 
 def sendreport():
@@ -272,8 +276,8 @@ def sendreport():
 
     #these values should be changed to the credentials of a Github account in order for the bug reports to be sent.
     access_token = 'f4343a5620d93a4cabac6a2950d217c2e17c2a9f'
-    USERNAME = 'hangde01'
-    PASSWORD = 'Guid3totheGalaxy'
+    USERNAME = 'USERNAME'
+    PASSWORD = 'PASSWORD'
     if request.vars['bookerror'] == 'on':
         print('checkbox not checked')
         basecourse = db(db.courses.course_name == request.vars['coursename']).select().first().base_course

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -154,9 +154,9 @@ def index():
         numCourses = 0
         for row in courseCheck:
             numCourses += 1
-            redirect('/%s/static/%s/index.html' % (request.application, course.course_name))
         if numCourses == 1:
-            redirect('/%s/default/courses' % request.application)
+            redirect('/%s/static/%s/index.html' % (request.application, course.course_name))
+        redirect('/%s/default/courses' % request.application)
 
     cohortId = db(db.auth_user.id == auth.user.id).select(db.auth_user.cohort_id).first()
 
@@ -217,9 +217,6 @@ def bios():
 
 @auth.requires_login()
 def courses():
-    #query courses db to get course names
-    #send course names to be rendered in page
-
     res = db(db.user_courses.user_id == auth.user.id).select(db.user_courses.course_id)
     classlist = []
     for row in res:
@@ -268,16 +265,27 @@ def reportabug():
     return dict()
 
 def sendreport():
+    print(request.vars['bookerror'])
+    for key in request.vars:
+        print(key)
+        print('key maps to', request.vars[key])
+
     #these values should be changed to the credentials of a Github account in order for the bug reports to be sent.
-    USERNAME = 'USERANME'
-    PASSWORD = 'PASSWORD'
-    basecourse = db(db.courses.course_name == request.vars['coursename']).select().first().base_course
-    if basecourse == None:
-        url = 'https://api.github.com/repos/RunestoneInteractive/%s/issues' % request.vars['coursename']
+    access_token = 'f4343a5620d93a4cabac6a2950d217c2e17c2a9f'
+    USERNAME = 'hangde01'
+    PASSWORD = 'Guid3totheGalaxy'
+    if request.vars['bookerror'] == 'on':
+        print('checkbox not checked')
+        basecourse = db(db.courses.course_name == request.vars['coursename']).select().first().base_course
+        if basecourse == None:
+            url = 'https://api.github.com/repos/RunestoneInteractive/%s/issues' % request.vars['coursename']
+        else:
+            url ='https://api.github.com/repos/RunestoneInteractive/%s/issues' % basecourse
     else:
-        url ='https://api.github.com/repos/RunestoneInteractive/%s/issues' % basecourse
+        url = 'https://api.github.com/repos/RunestoneInteractive/RunestoneComponents/issues'
     reqsession = requests.Session()
-    reqsession.auth = (USERNAME, PASSWORD)
+    #reqsession.auth = (USERNAME, PASSWORD)
+    reqsession.auth = ('token', access_token)
     body = 'Error reported in course ' + request.vars['coursename'] + ' on page ' + request.vars['pagename'] + '\n' + request.vars['bugdetails']
     issue = {'title': request.vars['bugtitle'],
              'body': body}

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ pylint==1.2.1
 pyparsing==2.0.3
 python-dateutil==2.4.2
 pytz==2015.4
+requests==2.10.0
 runestone>=2.0.5
 six==1.9.0
 snowballstemmer==1.2.0

--- a/views/default/reportabug.html
+++ b/views/default/reportabug.html
@@ -2,7 +2,7 @@
 
 <h1 style="text-align: center">Report a Bug</h1>
 
-<p>Sorry you are having trouble. I want to hear about problems you are having but before I send you off to github to report a bug please look over the following list of common problems and solutions:</p>
+<p>Sorry you are having trouble. I want to hear about problems you are having but before send a bug report please look over the following list of common problems and solutions:</p>
 <p>I can’t login, I can reset my password, but after that I can’t login again! This is definitely one of the most reported bugs. However in almost 100% of the cases so far, the problem is that you are using your email address as your username. When you registered you created a username, this is what you must use to login, not your email. IF you really are using the username you made and still having login problems then I want to hear from you.</p>
 <p>Very often, problems with activecode or exercises can be resolved by reloading your page a couple of times, or by clearing your cache.</p>
 <p>OK, now you are still running into some problem. Telling me that X does not work doesn’t really help. interactivepython.org gets over 30,000 pageviews a day from people around the world. So most of the time when someone says “X does not work” it does in fact work fine for most people. This does not make it your fault, it just means I need more information to try to make sense of what is going on. Fill out the following form to submit an error report on Github so that I can fix the problem.</p>
@@ -28,6 +28,12 @@
           <input type="text" class='form-control' placeholder="Page URL of the bug" name="pagename" id="pagename" required/>
         </div>
       </div>
+        <div class="form-group-row">
+            <div class="col-md-12">
+                <label for="bookerror"></label>
+                <input type="checkbox" name="bookerror" id="bookerror"> Check this box if the bug is a typo, unclear passage, or other problem with the content of a book.
+            </div>
+        </div>
         <div class="form-group">
             <div class="col-md-12">
                 <label for="bugdetails">Bug Details</label> <br/>

--- a/views/default/reportabug.html
+++ b/views/default/reportabug.html
@@ -1,0 +1,44 @@
+{{ extend 'layout.html'}}
+
+<h1 style="text-align: center">Report a Bug</h1>
+
+<p>Sorry you are having trouble. I want to hear about problems you are having but before I send you off to github to report a bug please look over the following list of common problems and solutions:</p>
+<p>I can’t login, I can reset my password, but after that I can’t login again! This is definitely one of the most reported bugs. However in almost 100% of the cases so far, the problem is that you are using your email address as your username. When you registered you created a username, this is what you must use to login, not your email. IF you really are using the username you made and still having login problems then I want to hear from you.</p>
+<p>Very often, problems with activecode or exercises can be resolved by reloading your page a couple of times, or by clearing your cache.</p>
+<p>OK, now you are still running into some problem. Telling me that X does not work doesn’t really help. interactivepython.org gets over 30,000 pageviews a day from people around the world. So most of the time when someone says “X does not work” it does in fact work fine for most people. This does not make it your fault, it just means I need more information to try to make sense of what is going on. Fill out the following form to submit an error report on Github so that I can fix the problem.</p>
+
+<div class="col-md-7">
+    <form name="bugform" id="bugform" action="/{{=request.application}}/{{=request.controller}}/sendreport" method="post">
+        <div class="form-group row">
+        <div class="col-md-4">
+          <label for="bugtitle">Bug Title</label>
+          <input type="text" class='form-control' name="bugtitle" id="bugtitle" required/>
+        </div>
+      </div>
+        <p>Enter a short title that summarises the bug</p>
+        <div class="form-group row">
+        <div class="col-md-4">
+          <label for="coursename">Course Name</label>
+          <input type="text" class='form-control' placeholder="thinkcspy, pythonds, or other" name="coursename" id="coursename" required/>
+        </div>
+      </div>
+       <div class="form-group row">
+        <div class="col-md-4">
+          <label for="pagename">Page URL</label>
+          <input type="text" class='form-control' placeholder="Page URL of the bug" name="pagename" id="pagename" required/>
+        </div>
+      </div>
+        <div class="form-group">
+            <div class="col-md-12">
+                <label for="bugdetails">Bug Details</label> <br/>
+                <textarea rows="4" cols="50" form="bugform" name="bugdetails" id="bugdetails" required></textarea>
+            </div>
+        </div>
+        <p>Please be as specific as possible. Include your username, the browser you are using, and any information from the Javascript Console.</p>
+        <div class="form-group row">
+             <div class="col-md-4">
+                <input type="submit" class="btn btn-default" value="Submit" />
+                 </div>
+            </div>
+    </form>
+</div>

--- a/views/groupLayout.html
+++ b/views/groupLayout.html
@@ -149,7 +149,7 @@
             <li><a href='/{{=request.application}}/static/overview/instructor.html'>Help for Instructors</a></li> 
             <li class="divider"></li>            
             <li><a href='http://runestoneinteractive.org'>About Runestone</a></li>
-            <li><a href='https://github.com/bnmnetp/runestone/issues/new'>Report A Problem</a></li>
+            <li><a href='/{{=request.application}}/default/reportabug/'>Report A Problem</a></li>
           </ul>
         </li>
 

--- a/views/layout.html
+++ b/views/layout.html
@@ -154,7 +154,7 @@
             <li><a href='/{{=request.application}}/static/overview/instructor.html'>Help for Instructors</a></li> 
             <li class="divider"></li>            
             <li><a href='http://runestoneinteractive.org'>About Runestone</a></li>
-            <li><a href='/{{=request.application}}/static/help/bugreports.html'>Report A Problem</a></li>
+            <li><a href='/{{=request.application}}/default/reportabug'>Report A Problem</a></li>
           </ul>
         </li>
 


### PR DESCRIPTION
I replaced the old problem page that directed the user to go to Github and report an issue there with a new page that, when the form is filled out and submitted, will automatically post a new issue into the the repository of the book that the problem originated in. This will require github credentials to be added into 'default.py'