### PR TITLE
Have term_start_date input only be determined by datepicker to solve issue #913

### DIFF
--- a/views/designer/index.html
+++ b/views/designer/index.html
@@ -144,7 +144,7 @@
       <div class="form-group row">
         <div class="col-md-3">
           <label for="startdate">Term start date </label>
-          <input type="text" name="startdate" id='startdate' class='form-control' data-date-format="mm/dd/yyyy" placeholder="{{=datetime.date.today().strftime('%m/%d/%Y')}}"/>
+          <input type="text" name="startdate" id='startdate' class='form-control' data-date-format="mm/dd/yyyy" placeholder="{{=datetime.date.today().strftime('%m/%d/%Y')}}" onkeydown='return false'/>
         </div>
       </div>
 


### PR DESCRIPTION
There is already a datepicker, but it's attached to a text input box that is still able to be typed in.  I've added an onkeydown='return false' to the cooresponding input tag, and that would solve the problem of users typing in dates, without breaking the datepicker. 