### PR TITLE
fixed instructor help link for home page and instructor pages to solve issue #906

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -154,7 +154,7 @@
           </a>
           <ul class="dropdown-menu user-menu">
 
-            <li><a href='/{{=request.application}}/static/overview/instructor.html'>Help for Instructors</a></li>
+            <li><a href='http://runestoneinteractive.org/customcourse.html'>Help for Instructors</a></li>
             <li class="divider"></li>
             <li><a href='http://runestoneinteractive.org'>About Runestone</a></li>
             <li><a href='/{{=request.application}}/default/reportabug'>Report A Problem</a></li>


### PR DESCRIPTION
I saw there was another issue similar to this one that has been closed, but I was still unable to reach the help page from the instructor help links in the home page or the instructor interface pages. (The help link did work from the table of contents page though.)