### PR TITLE
Fix: Allow more than 5 options in a multiple-choice question.

### DIFF
--- a/models/db_ebook.py
+++ b/models/db_ebook.py
@@ -110,7 +110,7 @@ db.define_table('mchoice_answers',
     Field('div_id','string'),
     Field('sid','string'),
     Field('course_name','string'),
-    Field('answer','string', length=10),
+    Field('answer','string', length=50),
     Field('correct','boolean'),
     migrate='runestone_mchoice_answers.table'
     )


### PR DESCRIPTION
The format is "0,1,2,3,4,5,...". With a length of 10, this is limited. I'm getting server-side exceptions on some of my (longer) multiple-choice questions.