### PR TITLE
Clean unit test

### DIFF
--- a/controllers/assignments.py
+++ b/controllers/assignments.py
@@ -420,7 +420,6 @@ def _score_one_code_run(row, points, autograde):
         pct_correct = 100 * float(passed)/(int(failed) + int(passed))
     except:
         pct_correct = 0 # can still get credit if autograde is 'interact' or 'visited'; but no autograded value
-    print "here", pct_correct
     return _score_from_pct_correct(pct_correct, points, autograde)
 
 def _score_one_mchoice(row, points, autograde):
@@ -560,16 +559,9 @@ def _scorable_codelens_answers(course_name, sid, question_name, points, deadline
     return db(query).select(orderby=db.codelens_answers.timestamp)
 
 def _autograde_one_q(course_name, sid, question_name, points, question_type, deadline=None, autograde=None, which_to_grade=None, save_score=True):
+
+
     logger.debug("autograding %s %s %s %s %s %s", course_name, question_name, sid, deadline, autograde, which_to_grade)
-    print """
-             course_name: {}
-             sid: {}
-             question_name {}
-             points {}
-             question_type {}
-             deadline {}
-             autograde {}
-             which_to_grade {}""".format(course_name, sid, question_name, points, question_type, deadline, autograde, which_to_grade)
     if not autograde:
         logger.debug("autograde not set returning 0")
         return 0
@@ -592,15 +584,12 @@ def _autograde_one_q(course_name, sid, question_name, points, question_type, dea
     #      affect how the score is determined.
 
     # get the results from the right table, and choose the scoring function
-    print "here 1"
     if question_type in ['activecode', 'actex']:
         if autograde in ['pct_correct', 'all_or_nothing', 'unittest']:
             event_filter = 'unittest'
         else:
             event_filter = None
         results = _scorable_useinfos(course_name, sid, question_name, points, deadline, event_filter)
-        print "here2", len(results)
-        print db._lastsql
         scoring_fn = _score_one_code_run
     elif question_type == 'mchoice':
         results = _scorable_mchoice_answers(course_name, sid, question_name, points, deadline)

--- a/models/grouped_assignments.py
+++ b/models/grouped_assignments.py
@@ -543,7 +543,8 @@ db.define_table('question_grades',
     Field('course_name',type='string', notnull=True),
     Field('div_id', type = 'string', notnull=True),
     Field('useinfo_id', db.useinfo), # the particular useinfo run that was graded
+    Field('deadline', 'datetime'),
     Field('score', type='double'),
-    Field('comment', type = 'text'),
+    Field('comment', type ='text'),
     migrate='runestone_question_grades.table',
     )

--- a/tests/make_clean_db_with_grades.py
+++ b/tests/make_clean_db_with_grades.py
@@ -1,0 +1,55 @@
+#
+# Unit Tests for AJAX API endpoints
+# Set up the environment variables
+# WEB2PY_CONFIG=test
+# TEST_DBURL=postgres://user:pw@host:port/dbname
+#
+#
+# Run these from the main web2py directory with the command:
+# python web2py.py -S runestone -M -R applications/runestone/tests/test_ajax.py
+#
+
+from gluon.globals import Request
+
+# bring in the assignments controllers
+execfile("applications/runestone/controllers/assignments.py", globals())
+
+# clean up the database
+db(db.useinfo.div_id == 'unit_test_1').delete()
+db.commit()
+
+# fetch all of the autograded questions_grades
+# with all the info about them
+graded = db((db.question_grades.comment == 'autograded') &
+            (db.question_grades.div_id == db.questions.name) &
+            (db.questions.id == db.assignment_questions.question_id) &
+            (db.assignment_questions.assignment_id == db.assignments.id)).select(
+    db.question_grades.id,
+    db.question_grades.course_name,
+    db.question_grades.sid,
+    db.question_grades.div_id,
+    db.question_grades.comment,
+    db.assignment_questions.id,
+    db.assignment_questions.points,
+    db.questions.id,
+    db.questions.question_type,
+    db.assignments.id,
+    db.assignments.duedate,
+    db.assignment_questions.autograde,
+    db.assignment_questions.which_to_grade,
+    db.question_grades.score)
+
+
+# for each one, recompute grade; alternate between using deadline and not
+use_deadline = True
+for g in graded:
+    sc = _autograde_one_q(course_name=g.question_grades.course_name,
+                                      sid=g.question_grades.sid,
+                                      question_name=g.question_grades.div_id,
+                                      points=g.assignment_questions.points,
+                                      question_type=g.questions.question_type,
+                                      deadline=g.assignments.duedate if use_deadline else None,
+                                      autograde=g.assignment_questions.autograde,
+                                      which_to_grade=g.assignment_questions.which_to_grade,
+                                      save_score=True)
+    use_deadline = not use_deadline

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -6,12 +6,19 @@
 set -e
 
 export WEB2PY_CONFIG=test
-export TEST_DBURL=postgres://bmiller:@localhost/runestone_test
+# HINT: make sure that 1.py has something like the following, that reads this environment variable
+#if os.environ.get("WEB2PY_CONFIG", None) == "test":
+#    settings.database_uri = 'postgres://dbusername:dbpassword@localhost/runestone_test'
+#else:
+#    settings.database_uri = 'your regular db string'
+
+# HINT: if using postgres, set an environment variable for PGUSER so that the database drops and creates will work
+# export PGUSER=dbusername
 
 # make sure runestone_test is nice and clean
 
-if [ $1 != "--skipdbinit" ]; then
-    dropdb --echo runestone_test
+if [ "$1" != "--skipdbinit" ]; then
+    dropdb --echo --if-exists runestone_test
     createdb --echo runestone_test
     psql runestone_test < runestone_test.sql
 else

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -7,13 +7,29 @@ set -e
 
 export WEB2PY_CONFIG=test
 # HINT: make sure that 1.py has something like the following, that reads this environment variable
-#if os.environ.get("WEB2PY_CONFIG", None) == "test":
-#    settings.database_uri = 'postgres://dbusername:dbpassword@localhost/runestone_test'
+#config = environ.get("WEB2PY_CONFIG","production")
+#
+#if config == "production":
+#    settings.database_uri = environ["DBURL"]
+#elif config == "development":
+#    settings.database_uri = environ.get("DEV_DBURL")
+#elif config == "test":
+#    settings.database_uri = environ.get("TEST_DBURL")
 #else:
-#    settings.database_uri = 'your regular db string'
+#    raise ValueError("unknown value for WEB2PY_CONFIG")
+
+# HINT: make sure that you export TEST_DBURL in your environment; not set here because it's specific to local
+# setup, possibly with a password, and thus can't be committed to the repo.
 
 # HINT: if using postgres, set an environment variable for PGUSER so that the database drops and creates will work
-# export PGUSER=dbusername
+# export PGUSER=<dbusername>
+
+# Ascend to the main web2py directory
+cd ../../../
+
+# To reset the unit test based on current grading code, uncomment these lines
+# python web2py.py -S runestone -M -R applications/runestone/tests/make_clean_db_with_grades.py
+# pg_dump runestone_test > runestone_test.sql
 
 # make sure runestone_test is nice and clean
 
@@ -25,8 +41,6 @@ else
     echo "Skipping DB initialization"
 fi
 
-# Ascend to the main web2py directory
-cd ../../../
-
 # Now run
 python web2py.py -S runestone -M -R applications/runestone/tests/test_ajax.py
+python web2py.py -S runestone -M -R applications/runestone/tests/test_assignments.py

--- a/tests/test_ajax.py
+++ b/tests/test_ajax.py
@@ -15,56 +15,10 @@ from gluon.globals import Request
 
 # bring in the ajax controllers
 execfile("applications/runestone/controllers/ajax.py", globals())
-execfile("applications/runestone/controllers/assignments.py", globals())
 
 # clean up the database
 db(db.useinfo.div_id == 'unit_test_1').delete()
 db.commit()
-
-
-class TestGradingFunction(unittest.TestCase):
-    def setUp(self):
-        request = Request(globals()) # Use a clean Request object
-
-    def testReproduceScores(self):
-        # fetch all of the autograded questions_grades
-        # with all the info about them
-        graded = db((db.question_grades.comment == 'autograded') &
-                    (db.question_grades.div_id == db.questions.name) &
-                    (db.questions.id == db.assignment_questions.question_id) &
-                    (db.assignment_questions.assignment_id == db.assignments.id)).select(
-                        db.question_grades.id,
-                        db.question_grades.course_name,
-                        db.question_grades.sid,
-                        db.question_grades.div_id,
-                        db.question_grades.comment,
-                        db.assignment_questions.id,
-                        db.assignment_questions.points,
-                        db.questions.id,
-                        db.questions.question_type,
-                        db.assignments.id,
-                        db.assignments.duedate,
-                        db.assignment_questions.autograde,
-                        db.assignment_questions.which_to_grade,
-                        db.question_grades.score)
-
-        # for each one, see if the computed score matches the recorded one
-        for g in graded:
-            sc = _autograde_one_q(course_name=g.question_grades.course_name,
-                                              sid=g.question_grades.sid,
-                                              question_name=g.question_grades.div_id,
-                                              points=g.assignment_questions.points,
-                                              question_type=g.questions.question_type,
-                                              deadline=g.assignments.duedate,
-                                              autograde=g.assignment_questions.autograde,
-                                              which_to_grade=g.assignment_questions.which_to_grade,
-                                              save_score=False)
-            print "~", sc
-            self.assertEqual(sc,
-                             g.question_grades.score,
-                             "Failed for graded question {}".format(g))
-
-
 
 class TestAjaxEndpoints(unittest.TestCase):
     def setUp(self):
@@ -91,7 +45,6 @@ class TestAjaxEndpoints(unittest.TestCase):
     def testInstructorStatus(self):
         auth.login_user(db.auth_user(11))
         course = 'testcourse'
-        verifyInstructorStatus(course, 11)
         self.assertTrue(verifyInstructorStatus(course,auth.user.id))
         auth.login_user(db.auth_user(1663))
         self.assertFalse(verifyInstructorStatus(course,auth.user.id))
@@ -110,6 +63,7 @@ class TestAjaxEndpoints(unittest.TestCase):
         request.vars.event = 'mChoice'
 
         res = getAssessResults()
+        print("RESULTS = ", res)
         res = json.loads(res)
         self.assertEqual(res['answer'], '1')
         self.assertEqual(res['correct'], True)
@@ -120,5 +74,4 @@ class TestAjaxEndpoints(unittest.TestCase):
 
 suite = unittest.TestSuite()
 suite.addTest(unittest.makeSuite(TestAjaxEndpoints))
-suite.addTest(unittest.makeSuite(TestGradingFunction))
 unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -1,0 +1,63 @@
+#
+# Unit Tests for AJAX API endpoints
+# Set up the environment variables
+# WEB2PY_CONFIG=test
+# TEST_DBURL=postgres://user:pw@host:port/dbname
+#
+#
+# Run these from the main web2py directory with the command:
+# python web2py.py -S runestone -M -R applications/runestone/tests/test_ajax.py
+#
+
+import unittest
+import json
+from gluon.globals import Request
+
+# bring in the assignments controllers
+execfile("applications/runestone/controllers/assignments.py", globals())
+
+class TestGradingFunction(unittest.TestCase):
+    def setUp(self):
+        request = Request(globals()) # Use a clean Request object
+
+    def testReproduceScores(self):
+        # fetch all of the autograded questions_grades
+        # with all the info about them
+        graded = db((db.question_grades.comment == 'autograded') &
+                    (db.question_grades.div_id == db.questions.name) &
+                    (db.questions.id == db.assignment_questions.question_id) &
+                    (db.assignment_questions.assignment_id == db.assignments.id)).select(
+                        db.question_grades.id,
+                        db.question_grades.course_name,
+                        db.question_grades.sid,
+                        db.question_grades.div_id,
+                        db.question_grades.comment,
+                        db.question_grades.deadline,
+                        db.assignment_questions.id,
+                        db.assignment_questions.points,
+                        db.questions.id,
+                        db.questions.question_type,
+                        db.assignments.id,
+                        db.assignments.duedate,
+                        db.assignment_questions.autograde,
+                        db.assignment_questions.which_to_grade,
+                        db.question_grades.score)
+
+        # for each one, see if the computed score matches the recorded one
+        for g in graded:
+            sc = _autograde_one_q(course_name=g.question_grades.course_name,
+                                              sid=g.question_grades.sid,
+                                              question_name=g.question_grades.div_id,
+                                              points=g.assignment_questions.points,
+                                              question_type=g.questions.question_type,
+                                              deadline=g.question_grades.deadline,
+                                              autograde=g.assignment_questions.autograde,
+                                              which_to_grade=g.assignment_questions.which_to_grade,
+                                              save_score=False)
+            self.assertEqual(sc,
+                             g.question_grades.score,
+                             "Failed for graded question {}".format(g))
+
+suite = unittest.TestSuite()
+suite.addTest(unittest.makeSuite(TestGradingFunction))
+unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This one should be clean, with no dependence on the lti updates. DB migration required because of addition of deadline field to question_grades, to record what deadline was used in computing the grade.