### PR TITLE
allow for / in subchapter names

### DIFF
--- a/controllers/assignments.py
+++ b/controllers/assignments.py
@@ -1244,7 +1244,7 @@ def doAssignment():
 
     for r in readings:
         logger.debug("READING = %s",r.name)
-        chapterSections = r.name.split('/')
+        chapterSections = r.name.split('/', 1)
 
         labels = db((db.chapters.chapter_name == chapterSections[0]) & \
                     (db.chapters.course_id == auth.user.course_name) & \


### PR DESCRIPTION
Subchapter names are taken from headers that people write in .rst files. So we should allow for / in them. This optional parameter to split just divides the string at the first /.