### PR TITLE
eliminate chapterSections variable

### DIFF
--- a/controllers/assignments.py
+++ b/controllers/assignments.py
@@ -1242,7 +1242,7 @@ def doAssignment():
 
     for r in readings:
         logger.debug("READING = %s",r.name)
-
+        # todo: eliminate this query
         labels = db((db.chapters.chapter_label == r.chapter) &
                     (db.chapters.course_id == auth.user.course_name) &
                     (db.chapters.id == db.sub_chapters.chapter_id) &

--- a/controllers/assignments.py
+++ b/controllers/assignments.py
@@ -1215,17 +1215,19 @@ def doAssignment():
                         (db.assignment_questions.reading_assignment == None or db.assignment_questions.reading_assignment != 'T')) \
                         .select(db.questions.htmlsrc, db.questions.id, db.questions.chapter, db.questions.subchapter, db.questions.name, orderby=db.assignment_questions.sorting_priority)
 
-    readings = db((db.assignment_questions.assignment_id == assignment.id) & \
-                (db.assignment_questions.question_id == db.questions.id) & \
-                (db.assignment_questions.reading_assignment == 'T')) \
-                .select(db.questions.base_course, db.questions.name, orderby=db.assignment_questions.sorting_priority)
+    readings = db((db.assignment_questions.assignment_id == assignment.id) &
+                  (db.assignment_questions.question_id == db.questions.id) &
+                  (db.assignment_questions.reading_assignment == 'T'))\
+        .select(db.questions.base_course, db.questions.name,
+                db.questions.chapter, db.questions.subchapter,
+                orderby=db.assignment_questions.sorting_priority)
 
-    questions_scores = db((db.assignment_questions.assignment_id == assignment.id) & \
-                    (db.assignment_questions.question_id == db.questions.id) & \
+    questions_scores = db((db.assignment_questions.assignment_id == assignment.id) &
+                    (db.assignment_questions.question_id == db.questions.id) &
                     (db.assignment_questions.reading_assignment == None or db.assignment_questions.reading_assignment != 'T') & \
-                    (db.question_grades.sid == auth.user.username) & \
+                    (db.question_grades.sid == auth.user.username) &
                     (db.question_grades.div_id == db.questions.name)) \
-                    .select(db.questions.id, db.question_grades.score, db.question_grades.comment, db.assignment_questions.points, orderby=db.assignment_questions.sorting_priority)
+        .select(db.questions.id, db.question_grades.score, db.question_grades.comment, db.assignment_questions.points, orderby=db.assignment_questions.sorting_priority)
 
     questionslist = []
     readingsDict = {}
@@ -1235,28 +1237,25 @@ def doAssignment():
     # Each value is a list of lists detailing the information about each section within the assigned chapter
     # Chapter ids are used as keys so the dictionary can be iterated in the correct order within doAssignment.html
 
-    # Because readings do not record chapters in the questions table
-    # assigned readings cannot (nicely) be grouped into chapters by a DB query yet
-    # so using a dictionary is a quick short-term solution to group all the sections to each chapter
-    # The chapters will appear in the order that they do in the ToC,
-    # but the sections within each chapter will appear according to the sorting_priority in assignment_questions
-
     # Once the questions table starts recording chapters for readings, a dictionary may not be needed anymore,
     # and the labels query won't be needed at all
 
     for r in readings:
         logger.debug("READING = %s",r.name)
-        chapterSections = r.name.split('/', 1) #todo: this can be replaced by pulling chapter and sub_chapter label from the question rather than inferring from split!
 
-        labels = db((db.chapters.chapter_name == chapterSections[0]) & \
-                    (db.chapters.course_id == auth.user.course_name) & \
-                    (db.chapters.id == db.sub_chapters.chapter_id) & \
-                    (db.sub_chapters.sub_chapter_name == chapterSections[1])) \
-                    .select(db.sub_chapters.chapter_id, db.sub_chapters.sub_chapter_name, db.sub_chapters.sub_chapter_label, db.chapters.chapter_name, db.chapters.chapter_label, db.chapters.id).first()
+        labels = db((db.chapters.chapter_label == r.chapter) &
+                    (db.chapters.course_id == auth.user.course_name) &
+                    (db.chapters.id == db.sub_chapters.chapter_id) &
+                    (db.sub_chapters.sub_chapter_label == r.subchapter)) \
+            .select(db.sub_chapters.chapter_id, db.sub_chapters.sub_chapter_name,
+                    db.sub_chapters.sub_chapter_label, db.chapters.chapter_name, db.chapters.chapter_label,
+                    db.chapters.id).first()
         logger.debug("LABELS = %s",labels)
         logger.debug("user_id = %s labels[chapters] = %s labels[sub_chapters] = %s",auth.user.id,labels['chapters'].chapter_label,labels['sub_chapters'].sub_chapter_label)
-        completion = db((db.user_sub_chapter_progress.user_id == auth.user.id) & \
-            (db.user_sub_chapter_progress.chapter_id == labels['chapters'].chapter_label) & \
+        chapter_name = labels.chapters.chapter_name
+        subchapter_name = labels.sub_chapters.sub_chapter_name
+        completion = db((db.user_sub_chapter_progress.user_id == auth.user.id) &
+            (db.user_sub_chapter_progress.chapter_id == labels['chapters'].chapter_label) &
             (db.user_sub_chapter_progress.sub_chapter_id == labels['sub_chapters'].sub_chapter_label)).select().first()
 
         # Sometimes when a sub-chapter is added to the book after the user has registerd and the
@@ -1276,11 +1275,11 @@ def doAssignment():
             readingsDict[labels['chapters'].id] = []
 
         if completion.status == 1:
-            readingsDict[labels['chapters'].id].append([chapterSections[0], chapterPath, chapterSections[1], sectionPath, 'completed'])
+            readingsDict[labels['chapters'].id].append([chapter_name, chapterPath, subchapter_name, sectionPath, 'completed'])
         elif completion.status == 0:
-            readingsDict[labels['chapters'].id].append([chapterSections[0], chapterPath, chapterSections[1], sectionPath, 'started'])
+            readingsDict[labels['chapters'].id].append([chapter_name, chapterPath, subchapter_name, sectionPath, 'started'])
         else:
-            readingsDict[labels['chapters'].id].append([chapterSections[0], chapterPath, chapterSections[1], sectionPath, 'notstarted'])
+            readingsDict[labels['chapters'].id].append([chapter_name, chapterPath, subchapter_name, sectionPath, 'notstarted'])
 
     # This is to get the chapters' completion states based on the completion of sections of the readings in assignments
     # The completion of chapters in reading assignments means that all the assigned sections for that specific chapter have been completed

--- a/scripts/find_modified_index.py
+++ b/scripts/find_modified_index.py
@@ -1,0 +1,23 @@
+import psycopg2
+import shutil
+import os, sys
+import filecmp
+import difflib
+
+conn = psycopg2.connect(os.environ['DBURL'])
+curs = conn.cursor()
+curs.execute('set session statement_timeout to 0')
+curs.execute('''select course_name, base_course from courses''')
+
+cleancount = 0
+
+for row in curs:
+    course = "custom_courses/{}/index.rst".format(row[0])
+    bc = "books/{}/_sources/index.rst".format(row[1])
+
+    if os.path.exists(course) and os.path.exists(bc):
+        print ("comparing {} to {}".format(course,bc))
+        res = filecmp.cmp(course, bc)
+        if not res:
+            print("{} is DIFFERENT".format(course))
+            sys.stdout.writelines(difflib.context_diff(open(course).readlines(), open(bc).readlines()))

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -147,6 +147,10 @@ class TestGradingFunction(unittest.TestCase):
         for i in res['readings'][7116]:
             self.assertEqual(i[-1], "completed")
             self.assertEqual(i[0], "General Introduction")
+
+        for i, r in enumerate(res['readings'][7116]):
+            self.assertEqual(r, rlist[i])
+
         self.assertEqual(len(res['questioninfo']),0)
         self.assertEqual('testcourse', res['course_name'])
         self.assertEqual('testcourse', res['course_id'])


### PR DESCRIPTION
This PR eliminates the extremely troublesome chapterSections variable.  The questions table does now include the chapter_label as well as the subchapter label and these are going to be much more reliable than inferring from the name. 

-- This may even fix the problem that occurs when an author does not follow the use of the toctree.rst per chapter pattern.

-- I should add that I wrote a unit test for doAssignment before doing this which passed on the test database and this test continues to pass with the new code in place -- Yay unit tests.
