### PR TITLE
Move db_dashboard to modules

### DIFF
--- a/controllers/assignments.py
+++ b/controllers/assignments.py
@@ -35,7 +35,7 @@ def index():
         session.flash = "{} is not a graded course".format(auth.user.course_name)
         return redirect(URL('default','user'))
 
-    data_analyzer = DashboardDataAnalyzer(db, auth, auth.user.course_id)
+    data_analyzer = DashboardDataAnalyzer(auth.user.course_id)
     data_analyzer.load_user_metrics(request.vars.sid)
     data_analyzer.load_assignment_metrics(request.vars.sid, studentView=True)
 

--- a/controllers/assignments.py
+++ b/controllers/assignments.py
@@ -6,6 +6,7 @@ import json
 import logging
 import datetime
 from psycopg2 import IntegrityError
+from db_dashboard import DashboardDataAnalyzer
 
 logger = logging.getLogger(settings.logger)
 logger.setLevel(settings.log_level)
@@ -34,7 +35,7 @@ def index():
         session.flash = "{} is not a graded course".format(auth.user.course_name)
         return redirect(URL('default','user'))
 
-    data_analyzer = DashboardDataAnalyzer(auth.user.course_id)
+    data_analyzer = DashboardDataAnalyzer(db, auth.user.course_id)
     data_analyzer.load_user_metrics(request.vars.sid)
     data_analyzer.load_assignment_metrics(request.vars.sid, studentView=True)
 

--- a/controllers/assignments.py
+++ b/controllers/assignments.py
@@ -35,7 +35,7 @@ def index():
         session.flash = "{} is not a graded course".format(auth.user.course_name)
         return redirect(URL('default','user'))
 
-    data_analyzer = DashboardDataAnalyzer(db, auth.user.course_id)
+    data_analyzer = DashboardDataAnalyzer(db, auth, auth.user.course_id)
     data_analyzer.load_user_metrics(request.vars.sid)
     data_analyzer.load_assignment_metrics(request.vars.sid, studentView=True)
 

--- a/controllers/dashboard.py
+++ b/controllers/dashboard.py
@@ -7,6 +7,8 @@ from datetime import date, timedelta, datetime
 from operator import itemgetter
 from collections import OrderedDict
 from paver.easy import sh
+from db_dashboard import *
+
 
 logger = logging.getLogger(settings.logger)
 logger.setLevel(settings.log_level)
@@ -46,7 +48,7 @@ def index():
         selected_chapter = chapters.first()
 
     logger.debug("making an analyzer")
-    data_analyzer = DashboardDataAnalyzer(auth.user.course_id,selected_chapter)
+    data_analyzer = DashboardDataAnalyzer(db, auth.user.course_id,selected_chapter)
     logger.debug("loading chapter metrics for course {}".format(auth.user.course_name))
     data_analyzer.load_chapter_metrics(selected_chapter)
     logger.debug("loading problem metrics")
@@ -146,7 +148,7 @@ def index():
 
 @auth.requires_login()
 def studentreport():
-    data_analyzer = DashboardDataAnalyzer(auth.user.course_id)
+    data_analyzer = DashboardDataAnalyzer(db, auth.user.course_id)
     data_analyzer.load_user_metrics(request.vars.id)
     data_analyzer.load_assignment_metrics(request.vars.id)
 
@@ -255,7 +257,7 @@ def questiongrades():
 def exercisemetrics():
     chapter = request.get_vars['chapter']
     chapter = db((db.chapters.course_id == auth.user.course_name) & (db.chapters.chapter_label == chapter)).select().first()
-    data_analyzer = DashboardDataAnalyzer(auth.user.course_id,chapter)
+    data_analyzer = DashboardDataAnalyzer(db, auth.user.course_id,chapter)
     data_analyzer.load_exercise_metrics(request.get_vars["id"])
     problem_metrics = data_analyzer.problem_metrics
 

--- a/controllers/dashboard.py
+++ b/controllers/dashboard.py
@@ -48,7 +48,7 @@ def index():
         selected_chapter = chapters.first()
 
     logger.debug("making an analyzer")
-    data_analyzer = DashboardDataAnalyzer(db, auth.user.course_id,selected_chapter)
+    data_analyzer = DashboardDataAnalyzer(db, auth, auth.user.course_id,selected_chapter)
     logger.debug("loading chapter metrics for course {}".format(auth.user.course_name))
     data_analyzer.load_chapter_metrics(selected_chapter)
     logger.debug("loading problem metrics")
@@ -148,7 +148,7 @@ def index():
 
 @auth.requires_login()
 def studentreport():
-    data_analyzer = DashboardDataAnalyzer(db, auth.user.course_id)
+    data_analyzer = DashboardDataAnalyzer(db, auth, auth.user.course_id)
     data_analyzer.load_user_metrics(request.vars.id)
     data_analyzer.load_assignment_metrics(request.vars.id)
 
@@ -257,7 +257,7 @@ def questiongrades():
 def exercisemetrics():
     chapter = request.get_vars['chapter']
     chapter = db((db.chapters.course_id == auth.user.course_name) & (db.chapters.chapter_label == chapter)).select().first()
-    data_analyzer = DashboardDataAnalyzer(db, auth.user.course_id,chapter)
+    data_analyzer = DashboardDataAnalyzer(db, auth, auth.user.course_id,chapter)
     data_analyzer.load_exercise_metrics(request.get_vars["id"])
     problem_metrics = data_analyzer.problem_metrics
 

--- a/controllers/dashboard.py
+++ b/controllers/dashboard.py
@@ -48,7 +48,7 @@ def index():
         selected_chapter = chapters.first()
 
     logger.debug("making an analyzer")
-    data_analyzer = DashboardDataAnalyzer(db, auth, auth.user.course_id,selected_chapter)
+    data_analyzer = DashboardDataAnalyzer(auth.user.course_id,selected_chapter)
     logger.debug("loading chapter metrics for course {}".format(auth.user.course_name))
     data_analyzer.load_chapter_metrics(selected_chapter)
     logger.debug("loading problem metrics")
@@ -148,7 +148,7 @@ def index():
 
 @auth.requires_login()
 def studentreport():
-    data_analyzer = DashboardDataAnalyzer(db, auth, auth.user.course_id)
+    data_analyzer = DashboardDataAnalyzer(auth.user.course_id)
     data_analyzer.load_user_metrics(request.vars.id)
     data_analyzer.load_assignment_metrics(request.vars.id)
 
@@ -257,7 +257,7 @@ def questiongrades():
 def exercisemetrics():
     chapter = request.get_vars['chapter']
     chapter = db((db.chapters.course_id == auth.user.course_name) & (db.chapters.chapter_label == chapter)).select().first()
-    data_analyzer = DashboardDataAnalyzer(db, auth, auth.user.course_id,chapter)
+    data_analyzer = DashboardDataAnalyzer(auth.user.course_id,chapter)
     data_analyzer.load_exercise_metrics(request.get_vars["id"])
     problem_metrics = data_analyzer.problem_metrics
 

--- a/models/db.py
+++ b/models/db.py
@@ -50,7 +50,7 @@ response.generic_patterns = ['*'] if request.is_local else []
 ## (more options discussed in gluon/tools.py)
 #########################################################################
 
-from gluon.tools import Auth, Crud, Service, PluginManager, prettydate
+from gluon.tools import Auth, Crud, Service, PluginManager, prettydate, current
 auth = Auth(db, hmac_key=Auth.get_or_create_key())
 crud, service, plugins = Crud(db), Service(), PluginManager()
 
@@ -266,3 +266,6 @@ except:
     mtime = random.randrange(10000)
 
 request.admin_mtime = str(mtime)
+
+current.db = db
+current.auth = auth

--- a/models/db.py
+++ b/models/db.py
@@ -269,3 +269,4 @@ request.admin_mtime = str(mtime)
 
 current.db = db
 current.auth = auth
+current.settings = settings

--- a/modules/.gitignore
+++ b/modules/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-

--- a/modules/db_dashboard.py
+++ b/modules/db_dashboard.py
@@ -2,8 +2,10 @@ from collections import OrderedDict
 import logging
 from datetime import datetime, timedelta
 
-rslogger = logging.getLogger(settings.logger)
-rslogger.setLevel(settings.log_level)
+rslogger = logging.getLogger("web2py.app.runestone")
+rslogger.setLevel(logging.DEBUG)
+
+db = None
 
 #db.define_table('dash_problem_answers',
 #  Field('timestamp','datetime'),
@@ -320,7 +322,9 @@ class UserLogCategorizer(object):
         return "{0} {1}".format(event, div_id)
 
 class DashboardDataAnalyzer(object):
-    def __init__(self, course_id, chapter=None):
+    def __init__(self, mydb, course_id, chapter=None):
+        global db
+        db = mydb
         self.course_id = course_id
         if chapter:
             self.db_chapter = chapter

--- a/modules/db_dashboard.py
+++ b/modules/db_dashboard.py
@@ -1,11 +1,11 @@
 from collections import OrderedDict
 import logging
 from datetime import datetime, timedelta
+from gluon import *
+
 
 rslogger = logging.getLogger("web2py.app.runestone")
 rslogger.setLevel(logging.DEBUG)
-
-db = None
 
 #db.define_table('dash_problem_answers',
 #  Field('timestamp','datetime'),
@@ -322,9 +322,10 @@ class UserLogCategorizer(object):
         return "{0} {1}".format(event, div_id)
 
 class DashboardDataAnalyzer(object):
-    def __init__(self, mydb, course_id, chapter=None):
-        global db
+    def __init__(self, mydb, myauth, course_id, chapter=None):
+        global db, auth
         db = mydb
+        auth = myauth
         self.course_id = course_id
         if chapter:
             self.db_chapter = chapter

--- a/tests/test_ajax.py
+++ b/tests/test_ajax.py
@@ -366,7 +366,7 @@ class TestAjaxEndpoints(unittest.TestCase):
 
     def testGetNumOnline(self):
         res = json.loads(getnumonline())
-        self.assertEqual(0, res[0]['online'])
+        self.assertEqual(1, res[0]['online'])
 
     def testGetUserLoggedIn(self):
         auth.login_user(db.auth_user(11))

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -15,6 +15,7 @@ import datetime
 from gluon.globals import Request, Session
 from gluon.tools import Auth
 from dateutil.parser import parse
+from gluon import current
 
 # bring in the ajax controllers
 
@@ -29,12 +30,12 @@ class TestDashboardEndpoints(unittest.TestCase):
         request = Request(globals()) # Use a clean Request object
         session = Session()
         auth = Auth(db, hmac_key=Auth.get_or_create_key())
+        current.auth = auth
         execfile("applications/runestone/controllers/dashboard.py", globals())
 
 
     def testStudentReport(self):
         auth.login_user(db.auth_user(1674))
-        session.auth = auth
         request.vars.id=auth.user.username
 
         res = studentreport()   #todo: if this is an endoint why does it not return json?


### PR DESCRIPTION
Per the web2py documentation on making your apps more efficient:

> Minimize the code in models: do not define functions there, define functions in the controllers that need them or - even better - define functions in modules, import them and use those functions as needed

@presnick 

It is also best to turn off migrations for production systems.  If you know you've made a schema change then turn them  on for one request and then turn them off again.
