### PR TITLE
Fix: Correctly specify URL for link.

### DIFF
--- a/views/dashboard/index.html
+++ b/views/dashboard/index.html
@@ -22,7 +22,7 @@
 					  {{pass}}
 					  {{pass}}
 					</select>
-					<button onclick="window.location.href='grades'">Gradebook</button>
+					<button onclick="window.location.href='{{=URL('grades')}}'">Gradebook</button>
 				</div>
 	<div class="col-md-7" style="">
 		<div class="dash-section">


### PR DESCRIPTION
Per our conversation on Slack, here's a webserver-independent way to specify the gradebook link.