### PR TITLE
pytest improvements + HTML fixes

### DIFF
--- a/controllers/ajax.py
+++ b/controllers/ajax.py
@@ -910,12 +910,12 @@ def checkTimedReset():
 
 def preview_question():
     code = json.loads(request.vars.code)
-    with open("applications/runestone/build/preview/_sources/index.rst", "w", encoding="utf-8") as ixf:
+    with open("applications/{}/build/preview/_sources/index.rst".format(request.application), "w", encoding="utf-8") as ixf:
         ixf.write(code)
 
-    res = os.system('applications/runestone/scripts/build_preview.sh')
+    res = os.system('applications/{}/scripts/build_preview.sh'.format(request.application))
     if res == 0:
-        with open('applications/runestone/build/preview/build/preview/index.html','r') as ixf:
+        with open('applications/{}/build/preview/build/preview/index.html'.format(request.application),'r') as ixf:
             src = ixf.read()
             tree = html.fromstring(src)
             component = tree.cssselect(".runestone")

--- a/controllers/coach.py
+++ b/controllers/coach.py
@@ -21,7 +21,7 @@ def get_lint(code, divid, sid):
 
     pyl_opts = ' --msg-template="{C}: {symbol}: {msg_id}:{line:3d},{column}: {obj}: {msg}" '
     pyl_opts += ' --reports=n '
-    pyl_opts += ' --rcfile='+os.path.join(os.getcwd(), "applications/runestone/pylintrc")
+    pyl_opts += ' --rcfile='+os.path.join(os.getcwd(), "applications/{}/pylintrc".format(request.application))
     #pyl_opts += ' --rcfile=' + os.path.join(os.getcwd(), "../pylintrc")
     try:
         (pylint_stdout, pylint_stderr) = lint.py_run(fn + pyl_opts, True, script='pylint')

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -169,7 +169,8 @@ def index():
 
         # check number of classes, if more than 1, send to course selection, if only 1, send to book
         num_courses = db(db.user_courses.user_id == auth.user.id).count()
-        if num_courses == 1:
+        # Don't redirect when there's only one course for testing. Since the static files don't exist, this produces a server error ``invalid file``.
+        if num_courses == 1 and os.environ.get('WEB2PY_CONFIG') != 'test':
             redirect('/%s/static/%s/index.html' % (request.application, course.course_name))
         redirect('/%s/default/courses' % request.application)
 
@@ -297,7 +298,7 @@ def removecourse():
         if row.course_name == request.args[0] and course_id_query:
             session.flash = T("Sorry, you cannot remove your current active course.")
         else:
-            db((db.user_courses.user_id == auth.user.id) & 
+            db((db.user_courses.user_id == auth.user.id) &
                (db.user_courses.course_id == course_id_query[0].id)).delete()
 
     redirect('/%s/default/courses' % request.application)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ coverage
 mock
 py_w3c
 pytest
+contextlib2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 coverage
 mock
 py_w3c
+pytest

--- a/tests/make_clean_db_with_grades.py
+++ b/tests/make_clean_db_with_grades.py
@@ -12,7 +12,7 @@
 from gluon.globals import Request
 
 # bring in the assignments controllers
-execfile("applications/runestone/modules/rs_grading.py", globals())
+execfile("applications/{}/modules/rs_grading.py".format(request.application), globals())
 
 # clean up the database
 db(db.useinfo.div_id == 'unit_test_1').delete()

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
     with pushd('../../..'):
         # Now run tests.
         xqt('{} -m coverage erase'.format(sys.executable),
-            '{} -m unittest applications.runestone.tests.test_server'.format(sys.executable),
+            '{} -m pytest applications/runestone/tests/test_server.py'.format(sys.executable),
             *['{} -m coverage run --append --source={} web2py.py -S runestone -M -R applications/runestone/tests/{}'.format(sys.executable, COVER_DIRS, x)
               for x in ['test_ajax.py', 'test_dashboard.py', 'test_admin.py', 'test_assignments.py']])
         xqt('{} -m coverage report'.format(sys.executable))

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
     with pushd('../../..'):
         # Now run tests.
         xqt('{} -m coverage erase'.format(sys.executable),
-            '{} -m pytest applications/runestone/tests/test_server.py'.format(sys.executable),
+            '{} -m pytest -v applications/runestone/tests/test_server.py'.format(sys.executable),
             *['{} -m coverage run --append --source={} web2py.py -S runestone -M -R applications/runestone/tests/{}'.format(sys.executable, COVER_DIRS, x)
               for x in ['test_ajax.py', 'test_dashboard.py', 'test_admin.py', 'test_assignments.py']])
         xqt('{} -m coverage report'.format(sys.executable))

--- a/tests/test_ajax.py
+++ b/tests/test_ajax.py
@@ -67,6 +67,7 @@ class Web2pyTestCase(unittest.TestCase):
     def setUp(self):
         global request, session, auth
         request = Request(globals())  # Use a clean Request object
+        request.application = 'runestone'
         session = Session()
         auth = Auth(db, hmac_key=Auth.get_or_create_key())
         # bring in the ajax controllers

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,22 +1,42 @@
 # *****************************************
 # |docname| - Tests using the web2py server
 # *****************************************
+# These tests start the web2py server then submit requests to it.
+#
+# .. contents::
+#
+# Imports
+# =======
+# These are listed in the order prescribed by `PEP 8
+# <http://www.python.org/dev/peps/pep-0008/#imports>`_.
+#
+# Standard library
+# ----------------
 import sys
 import time
 from subprocess import Popen
-import unittest
 from pprint import pprint
 
+# Third-party imports
+# -------------------
+import pytest
 from gluon.contrib.webclient import WebClient
 from py_w3c.validators.html.validator import HTMLValidator
 
+# Local imports
+# -------------
 from run_tests import COVER_DIRS
 from ci_utils import flush_print
 
 
-def setUpModule():
+# Fixtures
+# ========
+# This fixture starts and shuts down the web2py server.
+#
+# Execute this `fixture <https://docs.pytest.org/en/latest/fixture.html>`_ once per `module <https://docs.pytest.org/en/latest/fixture.html#scope-sharing-a-fixture-instance-across-tests-in-a-class-module-or-session>`_.
+@pytest.fixture(scope='module')
+def web2py_server():
     # Start the web2py server.
-    global web2py_server
     web2py_server = Popen(
         [sys.executable, '-m', 'coverage', 'run', '--append',
          '--source=' + COVER_DIRS, 'web2py.py', '-a', 'junk_password',
@@ -25,41 +45,102 @@ def setUpModule():
     time.sleep(1.5)
     flush_print('')
 
+    # After this comes the `teardown code <https://docs.pytest.org/en/latest/fixture.html#fixture-finalization-executing-teardown-code>`_.
+    yield web2py_server
 
-def tearDownModule():
     # Terminate the server to give web2py time to shut down gracefully.
     web2py_server.terminate()
 
 
-class TestServer(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.client = WebClient('http://127.0.0.1:8000/runestone/',
-                               postbacks=True)
+# This class implements the ``test_client`` fixture.
+class _TestClient(WebClient):
+    def __init__(self):
+        super(_TestClient, self).__init__('http://127.0.0.1:8000/runestone/',
+                                          postbacks=True)
+
+    # Use the W3C validator to check the HTML at the given URL.
+    def validate(self,
+        # The relative URL to validate.
+        url,
+        # An optional string that, if provided, must be in the text returned by the server
+        expected_string='',
+        # The number of validation errors expected
+        expected_errors=0):
+
+        self.get(url)
+        assert self.status == 200
+        if expected_string:
+            assert expected_string in self.text
+
+        vld = HTMLValidator()
+        vld.validate_fragment(self.text)
+        if len(vld.errors) != expected_errors:
+            print('Errors for {}: {}'.format(url, len(vld.errors)))
+            pprint(vld.errors)
+            # Save the HTML to make fixing the errors easier.
+            with open(url.replace('/', '-') + '.html', 'w') as f:
+                f.write(self.text.replace('\r\n', '\n'))
+            assert False
+        if vld.warnings:
+            print('Warnings for {}: {}'.format(url, len(vld.warnings)))
+            pprint(vld.warnings)
+
+
+# A fixture to create a client for accessing the server.
+@pytest.fixture(scope='class')
+def test_client(web2py_server):
+    return _TestClient()
+
+
+# Tests
+# =====
+# This class implements the ``test_user`` fixture.
+class _TestUser(object):
+    def __init__(self, test_client):
+        self.username = 'test_user_2'
+        self.password = 'password_2'
+        self.test_client = test_client
         # Create a user. First, get the form to read the CSRF key.
-        cls.client.get('default/user/register')
-        cls.client.post('default/user/register', data=dict(
-            username='test_user_2',
+        self.test_client.get('default/user/register')
+        ret = dict(
+            username=self.username,
             first_name='test',
             last_name='user_2',
             email='test_user_2@foo.com',
-            password='password_2',
-            password_two='password_2',
+            password=self.password,
+            password_two=self.password,
             # If this user is only enrolled in one course, ``models.default.index`` will redirect to it after registration, which (unless that book is built) will cause a bizarre web2py error, ``invalid file``. Using the ``boguscourse`` avoids this redirect.
             course_id='boguscourse',
             accept_tcp='on',
             donate='0',
             _next='/runestone/default/index',
             _formname='register',
+        )
+        self.test_client.post('default/user/register', data=ret)
+
+    def login(self):
+        self.test_client.post('default/user/login', data=dict(
+            username=self.username,
+            password=self.password,
+            _formname='login',
         ))
 
     def logout(self):
-        self.client.get('default/user/logout')
-        self.assertEquals(self.client.status, 200)
+        self.test_client.get('default/user/logout')
+        assert self.test_client.status == 200
 
+
+# This fixture creates a user for use with testing. Do it once per class to save time.
+@pytest.fixture(scope='class')
+def test_user(test_client):
+    yield _TestUser(test_client)
+    # TODO: Delete the user from the database.
+
+
+class TestServer(object):
     # Validate the HTML produced by various web2py pages.
-    def test_1(self):
-        for url, expected_values in {
+    def test_1(self, test_client, test_user):
+        for url, (requires_login, expected_string, expected_errors) in {
             # The `authentication <http://web2py.com/books/default/chapter/29/09/access-control#Authentication>`_ section gives the URLs exposed by web2py. Check these.
             'user/login': (False, 'Login', 1),
             'user/register': (False, 'Registration', 1),
@@ -74,8 +155,8 @@ class TestServer(unittest.TestCase):
             # This doesn't display a webpage, but instead redirects to courses.
             #'user/reset_password=(False, 'Reset password', 1),
             'user/impersonate': (True, 'Impersonate', 1),
-            # This produces an exception.
-            #'user/groups'=(True, 'Groups', 1),
+            # FIXME: This produces an exception.
+            #'user/groups': (True, 'Groups', 1),
             'user/not_authorized': (False, 'Not authorized', 1),
             # Returns a 404.
             #'user/navbar'=(False, 'xxx', 1),
@@ -92,42 +173,9 @@ class TestServer(unittest.TestCase):
             'privacy': (False, 'Runestone Academy Privacy Policy', 1),
             'donate': (False, 'Support Runestone Interactive', 1),
         }.iteritems():
-            requires_login, expected_string, expected_errors = expected_values
             if requires_login:
-                self.client.post('default/user/login', data=dict(
-                    username='test_user_2',
-                    password='password_2',
-                    _formname='login',
-                ))
+                test_user.login()
             else:
-                self.logout()
-            self.validate('default/' + url, expected_string, expected_errors)
-
-    # Use the W3C validator to check the HTML at the given URL.
-    def validate(self,
-        # The relative URL to validate.
-        url,
-        # An optional string that, if provided, must be in the text returned by the server
-        expected_string='',
-        # The number of validation errors expected
-        expected_errors=0):
-
-        self.client.get(url)
-        self.assertEqual(self.client.status, 200)
-        with open(url.replace('/', '-') + '.html', 'w') as f:
-            f.write(self.client.text.replace('\r\n', '\n'))
-        if expected_string:
-            self.assertIn(expected_string, self.client.text)
-
-        vld = HTMLValidator()
-        vld.validate_fragment(self.client.text)
-        if len(vld.errors) != expected_errors:
-            print('Errors for {}: {}'.format(url, len(vld.errors)))
-            pprint(vld.errors)
-            # Save the HTML to make fixing the errors easier.
-            with open(url.replace('/', '-') + '.html', 'w') as f:
-                f.write(self.client.text.replace('\r\n', '\n'))
-            self.assertTrue(False)
-        if vld.warnings:
-            print('Warnings for {}: {}'.format(url, len(vld.warnings)))
-            pprint(vld.warnings)
+                test_user.logout()
+            test_client.validate('default/' + url, expected_string,
+                                 expected_errors)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,19 +14,40 @@
 # ----------------
 import sys
 import time
-from subprocess import Popen
+import subprocess
 from pprint import pprint
+from contextlib import contextmanager
+from io import open
 
 # Third-party imports
 # -------------------
 import pytest
 from gluon.contrib.webclient import WebClient
+import gluon.shell
 from py_w3c.validators.html.validator import HTMLValidator
+from contextlib2 import ExitStack
 
 # Local imports
 # -------------
 from run_tests import COVER_DIRS
-from ci_utils import flush_print
+
+
+# Utilities
+# =========
+# Given a dictionary, convert it to an object. For example, if ``d['one'] == 1``, then after ``do = DictToObject(d)``, ``do.one == 1``.
+class DictToObject(object):
+    def __init__(self, _dict):
+        self.__dict__.update(_dict)
+
+
+# Create a web2py controller environment. This is taken from pieces of ``gluon.shell.run``. Given ``ctl_env = web2py_controller('app_name')``, then  ``ctl_env.db`` refers to the usual DAL object for database access, ``ctl_env.request`` is an (empty) Request object, etc.
+def web2py_controller(
+        # The name of the aLpplication to run in, as a string.
+        application):
+
+    _env = gluon.shell.env(application, import_models=True)
+    _env.update(gluon.shell.exec_pythonrc())
+    return DictToObject(_env)
 
 
 # Fixtures
@@ -37,13 +58,12 @@ from ci_utils import flush_print
 @pytest.fixture(scope='module')
 def web2py_server():
     # Start the web2py server.
-    web2py_server = Popen(
+    web2py_server = subprocess.Popen(
         [sys.executable, '-m', 'coverage', 'run', '--append',
          '--source=' + COVER_DIRS, 'web2py.py', '-a', 'junk_password',
          '--nogui'])
     # Wait for the server to come up. The delay varies; this is a guess.
     time.sleep(1.5)
-    flush_print('')
 
     # After this comes the `teardown code <https://docs.pytest.org/en/latest/fixture.html#fixture-finalization-executing-teardown-code>`_.
     yield web2py_server
@@ -52,7 +72,90 @@ def web2py_server():
     web2py_server.terminate()
 
 
-# This class implements the ``test_client`` fixture.
+# Create fixture providing a web2py controller environment for a Runestone application.
+@pytest.fixture
+def runestone_controller():
+    return web2py_controller('runestone')
+
+
+# Provide acess the the Runestone database through a fixture.
+@pytest.fixture
+def runestone_db(runestone_controller):
+    db = runestone_controller.db
+    yield db
+    # In case of an error, roll back the last transaction to leave the
+    # database in a working state. Also, attempt to leave the database in a
+    # clean state for the next test.
+    db.rollback()
+
+
+# Provide context managers for manipulating the Runestone database.
+class _RunestoneDbTools(object):
+    def __init__(self, runestone_db):
+        self.db = runestone_db
+
+    # Create a new course. It returns the course_id of the created course.
+    @contextmanager
+    def create_course(self,
+        # The name of the course to create, as a string.
+        course_name='test_course_1',
+        # The start date of the course, as a string.
+        term_start_date='2000-01-01',
+        # The value of the ``login_required`` flag for the course.
+        login_required=True):
+
+        course_id = self.db.courses.insert(
+            course_name=course_name, base_course=course_name,
+            term_start_date=term_start_date,
+            login_required=login_required,
+        )
+        self.db.commit()
+        try:
+            yield course_id
+        finally:
+            # Remove this from the database.
+            del self.db.courses[course_id]
+            self.db.commit()
+
+    @contextmanager
+    def add_user_to_course(self, user_id, course_id):
+        user_courses_id = self.db.user_courses.insert(course_id=course_id, user_id=user_id)
+        self.db.commit()
+        try:
+            yield user_courses_id
+        finally:
+            del self.db.user_courses[user_courses_id]
+            self.db.commit()
+
+
+    @contextmanager
+    def make_instructor(self,
+        # The ID of the user to make an instructor.
+        user_id,
+        # The ID of the course in which the user will be an instructor.
+        course_id):
+
+        course_instructor_id =  self.db.course_instructor.insert(course=course_id, instructor=user_id)
+        self.db.commit()
+        db = self.db
+        print(db((db.course_instructor.course == course_id) &
+             (db.course_instructor.instructor == user_id)
+            ).count())
+        try:
+            yield course_instructor_id
+        finally:
+            # Remove this from the database.
+            del self.db.course_instructor[course_instructor_id]
+            self.db.commit()
+
+
+# Present ``_RunestoneDbTools`` as a fixture.
+@pytest.fixture
+def runestone_db_tools(runestone_db):
+    return _RunestoneDbTools(runestone_db)
+
+
+# Create a client for accessing the Runestone server.
 class _TestClient(WebClient):
     def __init__(self):
         super(_TestClient, self).__init__('http://127.0.0.1:8000/runestone/',
@@ -64,59 +167,109 @@ class _TestClient(WebClient):
         url,
         # An optional string that, if provided, must be in the text returned by the server
         expected_string='',
-        # The number of validation errors expected
-        expected_errors=0):
+        # The number of validation errors expected. If None, no validation is performed.
+        expected_errors=None):
 
-        self.get(url)
-        assert self.status == 200
-        if expected_string:
-            assert expected_string in self.text
+        try:
+            self.get(url)
+            assert self.status == 200
+            if expected_string:
+                assert expected_string in self.text
 
-        vld = HTMLValidator()
-        vld.validate_fragment(self.text)
-        if len(vld.errors) != expected_errors:
-            print('Errors for {}: {}'.format(url, len(vld.errors)))
-            pprint(vld.errors)
-            # Save the HTML to make fixing the errors easier.
-            with open(url.replace('/', '-') + '.html', 'w') as f:
+            if expected_errors is not None:
+                vld = HTMLValidator()
+                vld.validate_fragment(self.text)
+                if len(vld.errors) != expected_errors:
+                    print('Errors for {}: {}'.format(url, len(vld.errors)))
+                    pprint(vld.errors)
+                    assert False
+                if vld.warnings:
+                    print('Warnings for {}: {}'.format(url, len(vld.warnings)))
+                    pprint(vld.warnings)
+
+        except AssertionError:
+            # Save the HTML to make fixing the errors easier. Note that ``self.text`` is already encoded as utf-8.
+            with open(url.replace('/', '-') + '.html', 'wb') as f:
                 f.write(self.text.replace('\r\n', '\n'))
-            assert False
-        if vld.warnings:
-            print('Warnings for {}: {}'.format(url, len(vld.warnings)))
-            pprint(vld.warnings)
+            raise
+
+    def logout(self):
+        self.get('default/user/logout')
+        assert self.status == 200
+
+    # Always logout after a test finishes.
+    def tearDown(self):
+        self.logout()
 
 
-# A fixture to create a client for accessing the server.
-@pytest.fixture(scope='class')
+# Present ``_TestClient`` as a fixure.
+@pytest.fixture
 def test_client(web2py_server):
-    return _TestClient()
+    tc = _TestClient()
+    yield tc
+    tc.tearDown()
 
 
-# Tests
-# =====
-# This class implements the ``test_user`` fixture.
+# This class allows creating a user inside a context manager.
 class _TestUser(object):
-    def __init__(self, test_client):
-        self.username = 'test_user_2'
-        self.password = 'password_2'
+    def __init__(self, test_client, runestone_db_tools, username, password, course_name):
         self.test_client = test_client
-        # Create a user. First, get the form to read the CSRF key.
+        self.runestone_db_tools = runestone_db_tools
+        self.username = username
+        self.password = password
+        self.course_name = course_name
+
+    def __enter__(self):
+        # Registration doesn't work unless we're logged out.
+        self.test_client.logout()
+        # First get the form to read the CSRF key, so that registration will work.
         self.test_client.get('default/user/register')
-        ret = dict(
+        # Now, post the registration.
+        self.test_client.post('default/user/register', data=dict(
             username=self.username,
             first_name='test',
-            last_name='user_2',
-            email='test_user_2@foo.com',
+            last_name='user',
+            # The e-mail address must be unique.
+            email=self.username + '@foo.com',
             password=self.password,
             password_two=self.password,
-            # If this user is only enrolled in one course, ``models.default.index`` will redirect to it after registration, which (unless that book is built) will cause a bizarre web2py error, ``invalid file``. Using the ``boguscourse`` avoids this redirect.
-            course_id='boguscourse',
+            # Note that ``course_id`` is (on the form) actually a course name.
+            course_id=self.course_name,
             accept_tcp='on',
             donate='0',
             _next='/runestone/default/index',
             _formname='register',
-        )
-        self.test_client.post('default/user/register', data=ret)
+        ))
+        # If this fails, write the resulting HTML to a file.
+        try:
+            assert self.test_client.status == 200
+            assert 'Course Selection' in self.test_client.text
+        except AssertionError:
+            with open('register.html', 'wb') as f:
+                f.write(self.test_client.text)
+            raise
+
+        # Schedule this user for deletion.
+        self.exit_stack_object = ExitStack()
+        self.exit_stack = self.exit_stack_object.__enter__()
+        self.exit_stack.callback(self._delete_user)
+
+        # Record the ID of this course.
+        db = self.runestone_db_tools.db
+        self.course_id = db(db.courses.course_name == self.course_name).select(db.courses.id).first().id
+
+        # Finally, add the user to the specified course and schedule it for deletion.
+        db = self.runestone_db_tools.db
+        self.user_id = db(db.auth_user.username == self.username).select(db.auth_user.id).first().id
+        self.exit_stack.enter_context(self.runestone_db_tools.add_user_to_course(self.user_id, self.course_id))
+
+        return self
+
+    # Delete the user created by entering this context manager.
+    def _delete_user(self):
+        db = self.runestone_db_tools.db
+        db(db.auth_user.username == self.username).delete()
+        db.commit()
 
     def login(self):
         self.test_client.post('default/user/login', data=dict(
@@ -125,57 +278,124 @@ class _TestUser(object):
             _formname='login',
         ))
 
-    def logout(self):
-        self.test_client.get('default/user/logout')
-        assert self.test_client.status == 200
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.exit_stack_object.__exit__(exc_type, exc_value, traceback)
 
 
-# This fixture creates a user for use with testing. Do it once per class to save time.
-@pytest.fixture(scope='class')
-def test_user(test_client):
-    yield _TestUser(test_client)
-    # TODO: Delete the user from the database.
+# Present ``_TestUser`` as a fixture.
+@pytest.fixture
+def test_user(test_client, runestone_db_tools):
+    return lambda *args, **kwargs: _TestUser(test_client, runestone_db_tools, *args, **kwargs)
 
 
-class TestServer(object):
-    # Validate the HTML produced by various web2py pages.
-    def test_1(self, test_client, test_user):
-        for url, (requires_login, expected_string, expected_errors) in {
-            # The `authentication <http://web2py.com/books/default/chapter/29/09/access-control#Authentication>`_ section gives the URLs exposed by web2py. Check these.
-            'user/login': (False, 'Login', 1),
-            'user/register': (False, 'Registration', 1),
-            'user/logout': (True, 'Logged out', 1),
-            # One profile error is a result of removing the input field for the e-mail, but web2py still tries to label it, which is an error.
-            'user/profile': (True, 'Profile', 2),
-            'user/change_password': (True, 'Change password', 1),
-            # Runestone doesn't support this.
-            #'user/verify_email': (False, 'Verify email', 1),
-            'user/retrieve_username': (False, 'Retrieve username', 1),
-            'user/request_reset_password': (False, 'Request reset password', 1),
-            # This doesn't display a webpage, but instead redirects to courses.
-            #'user/reset_password=(False, 'Reset password', 1),
-            'user/impersonate': (True, 'Impersonate', 1),
-            # FIXME: This produces an exception.
-            #'user/groups': (True, 'Groups', 1),
-            'user/not_authorized': (False, 'Not authorized', 1),
-            # Returns a 404.
-            #'user/navbar'=(False, 'xxx', 1),
+# Tests
+# =====
+# Validate the HTML produced by various web2py pages.
+@pytest.mark.parametrize('url, requires_login, expected_string, expected_errors',
+[
+    # The `authentication <http://web2py.com/books/default/chapter/29/09/access-control#Authentication>`_ section gives the URLs exposed by web2py. Check these.
+    ('default/user/login', False, 'Login', 1),
+    ('default/user/register', False, 'Registration', 1),
+    ('default/user/logout', True, 'Logged out', 1),
+    # One profile error is a result of removing the input field for the e-mail, but web2py still tries to label it, which is an error.
+    ('default/user/profile', True, 'Profile', 2),
+    ('default/user/change_password', True, 'Change password', 1),
+    # Runestone doesn't support this.
+    #'default/user/verify_email', False, 'Verify email', 1),
+    ('default/user/retrieve_username', False, 'Retrieve username', 1),
+    ('default/user/request_reset_password', False, 'Request reset password', 1),
+    # This doesn't display a webpage, but instead redirects to courses.
+    #('default/user/reset_password, False, 'Reset password', 1),
+    ('default/user/impersonate', True, 'Impersonate', 1),
+    # FIXME: This produces an exception.
+    #'default/user/groups', True, 'Groups', 1),
+    ('default/user/not_authorized', False, 'Not authorized', 1),
+    # Returns a 404.
+    #('default/user/navbar'=(False, 'xxx', 1),
 
-            # Other pages in ``default``.
-            'about': (False, 'About Us', 1),
-            'error': (False, 'Error: the document does not exist', 1),
-            'ack': (False, 'Acknowledgements', 1),
-            # web2py generates invalid labels for the radio buttons in this form.
-            'bio': (True, 'Tell Us About Yourself', 3),
-            'courses': (True, 'Course Selection', 1),
-            'remove': (True, 'Remove a Course', 1),
-            'reportabug': (False, 'Report a Bug', 1),
-            'privacy': (False, 'Runestone Academy Privacy Policy', 1),
-            'donate': (False, 'Support Runestone Interactive', 1),
-        }.iteritems():
-            if requires_login:
-                test_user.login()
-            else:
-                test_user.logout()
-            test_client.validate('default/' + url, expected_string,
-                                 expected_errors)
+    # Other pages in ``default``.
+    #
+    # TODO: What is this for?
+    #('default/call', False, 'Not found', 0),
+    # TODO: weird returned HTML. ???
+    #('default/index', True, 'Course Selection', 1),
+
+    ('default/about', False, 'About Us', 1),
+    ('default/error', False, 'Error: the document does not exist', 1),
+    ('default/ack', False, 'Acknowledgements', 1),
+    # web2py generates invalid labels for the radio buttons in this form.
+    ('default/bio', True, 'Tell Us About Yourself', 3),
+    ('default/courses', True, 'Course Selection', 1),
+    ('default/remove', True, 'Remove a Course', 1),
+    # FIXME: This produces an exception.
+    #('default/coursechooser', True, 'xxx', 1),
+    # FIXME: This produces an exception.
+    #('default/removecourse', True, 'xxx', 1),
+    # Should work in both cases.
+    ('default/reportabug', False, 'Report a Bug', 1),
+    ('default/reportabug', True, 'Report a Bug', 1),
+    # TODO: weird returned HTML. ???
+    #('default/sendreport', True, 'Could not create issue', 1),
+    ('default/terms', False, 'Terms and Conditions', 1),
+    ('default/privacy', False, 'Runestone Academy Privacy Policy', 1),
+    ('default/donate', False, 'Support Runestone Interactive', 1),
+
+    # Assignments
+    ('assignments/index', True, 'Student Progress for', 1),
+    # FIXME: There's a duplicated id ``fb-root`` on this page.
+    ('assignments/practice', True, 'Practice tool is not set up for this course yet.', 2),
+    ('assignments/chooseAssignment', True, 'Assignments', 1),
+
+    # Misc
+    ('oauth/index', False, 'This page is a utility for accepting redirects from external services like Spotify or LinkedIn that use oauth.', 1),
+    # FIXME: Not sure what's wrong here.
+    #('admin/index', False, 'You must be registered for a course to access this page', 1),
+    #('admin/index', True, 'You must be an instructor to access this page', 1),
+    ('admin/doc', True, 'Runestone Help and Documentation', 1),
+
+    ('dashboard/index', True, 'Instructor Dashboard', 1),
+    ('dashboard/grades', True, 'Gradebook', 1),
+    # TODO: Many other views!
+])
+def test_1(url, requires_login, expected_string, expected_errors, test_client,
+           test_user, runestone_db_tools):
+    with runestone_db_tools.create_course('test_course_1'), \
+        test_user('test_user_1', 'password_1', 'test_course_1') as test_user_1:
+        if requires_login:
+            test_user_1.login()
+        else:
+            test_client.logout()
+        test_client.validate(url, expected_string,
+                             expected_errors)
+
+
+# Test instructor-only pages.
+@pytest.mark.parametrize('url, expected_string, expected_errors',
+[
+    # web2py-generated stuff produces two extra errors.
+    ('default/bios', 'Bios', 3),
+    # FIXME: The element ``<form id="editIndexRST" action="">`` in ``views/admin/admin.html`` produces the error ``Bad value \u201c\u201d for attribute \u201caction\u201d on element \u201cform\u201d: Must be non-empty.``.
+    ('admin/admin', 'Manage Section', 2),
+    ('admin/grading', 'assignment', 1),
+    # FIXME: these raise an exception.
+    #('admin/assignments', 'Assignment', 1),
+    #('admin/practice', 'Choose the sections taught, so that students can practice them.', 1),
+])
+def test_2(url, expected_string, expected_errors, test_client,
+           test_user, runestone_db_tools):
+    with runestone_db_tools.create_course('test_course_1'), \
+        test_user('test_user_1', 'password_1', 'test_course_1') as test_user_1, \
+        test_user('test_instructor_1', 'password_1', 'test_course_1') as test_instructor_1, \
+        runestone_db_tools.make_instructor(test_instructor_1.user_id, test_instructor_1.course_id):
+
+        # Make sure that non-instructors are redirected.
+        test_client.logout()
+        test_client.validate(url, 'Login')
+        test_user_1.login()
+        test_client.validate(url, 'Insufficient privileges')
+        test_client.logout()
+
+        # Test the instructor results.
+        test_instructor_1.login()
+        test_client.validate(url, expected_string,
+                             expected_errors)

--- a/views/admin/admin.html
+++ b/views/admin/admin.html
@@ -31,7 +31,7 @@
 
 
 
-            <form  style="margin-top: 20px;" action="/runestone/sections/newCourse" method="post">
+            <form  style="margin-top: 20px;" action="/{{=request.application}}/sections/newCourse" method="post">
                 <button style="text-align: center; font-size: 12pt;" class="list-group-item" type="submit">New Course</button>
                 </form>
             </div>
@@ -41,7 +41,7 @@
           <div class="tab-content">
 
               <div id="manageStudents" class="tab-pane fade">
-                  <form id="removeStudents" method="POST" action="/runestone/admin/removeStudents">
+                  <form id="removeStudents" method="POST" action="/{{=request.application}}/admin/removeStudents">
                       <div class="col-md-3">
                           <h3 style="text-align: center">Students</h3>
                           <select id="studentList" class="form-control" size="10" name="studentList" multiple>
@@ -68,10 +68,10 @@
 
 
 
-         <form class="button" action="/runestone/sections/addSection" method="post" style="display: inline-block">
+         <form class="button" action="/{{=request.application}}/sections/addSection" method="post" style="display: inline-block">
              <input style="width: 35px; height:30px; margin-top: 12px;" type="submit" value="+"></form>
 
-                <form class="button" action="/runestone/sections/remove" method="post" style="display: inline-block">
+                <form class="button" action="/{{=request.application}}/sections/remove" method="post" style="display: inline-block">
                 <input style="width: 35px; height:30px;" type="submit" value="-">
                 </form>
 
@@ -89,7 +89,7 @@
             <a data-toggle="tab" href="#students" class="list-group-item">
                     <h4 style="text-align: center" class="list-group-item-heading">{{=startDate}}</h4>
                 </a>
-                <form class="button" action="/runestone/sections/changeDate" method="post" style="text-align: center">
+                <form class="button" action="/{{=request.application}}/sections/changeDate" method="post" style="text-align: center">
              <input style="width: 50%; height:30px; margin-top: 12px;" type="submit" value="Change Date"></form>
                 </div>
 
@@ -116,7 +116,7 @@
       <h4 style="text-align: center">Change Log</h4>
       <div style="border: groove; white-space: pre" id="changelog"></div>
 
-    <form name="confirm" method="POST" action="/runestone/admin/admin">
+    <form name="confirm" method="POST" action="/{{=request.application}}/admin/admin">
       <input type="hidden" name="projectname" value="{{=coursename}}" />
       <input type="hidden" name="coursetype" value="rebuildcourse" />
       <div class="checkbox">
@@ -147,7 +147,7 @@
 
 
 
-      <form  method="post" action="/runestone/admin/backup" style="margin-top: 16px;">
+      <form  method="post" action="/{{=request.application}}/admin/backup" style="margin-top: 16px;">
                 <input type="submit" class="btn btn-default" value="Download Backup"/>
                 </form>
 
@@ -336,7 +336,7 @@
     $('#AddInstructorTab').css('background-color','transparent');
         $('#DeleteTab').css('background-color','transparent');
             var obj = new XMLHttpRequest();
-        obj.open('GET','/runestone/admin/indexrst/', true);
+        obj.open('GET','/{{=request.application}}/admin/indexrst/', true);
         obj.send(JSON.stringify({avariable: 'avariable'}));
         obj.onreadystatechange = function() {
             if (obj.readyState == 4 && obj.status == 200) {
@@ -355,7 +355,7 @@
 
 
         var obj = new XMLHttpRequest();
-        obj.open("GET", "/runestone/admin/getChangeLog", true);
+        obj.open("GET", "/{{=request.application}}/admin/getChangeLog", true);
         obj.send(JSON.stringify({variable: 'variable'}));
         obj.onreadystatechange = function () {
 

--- a/views/admin/diffviewer.html
+++ b/views/admin/diffviewer.html
@@ -30,7 +30,7 @@ getDiffs = function(sid, divid) {
 
     params.divid = divid || $("#exerciseid").val();
     params.sid = sid || $("#studentid").val();
-    $.get("/runestone/ajax/getCodeDiffs", params, function(data) {
+    $.get("/{{=request.application}}/ajax/getCodeDiffs", params, function(data) {
         diffdata = JSON.parse(data);
         diffcount = diffdata.code.length-1;
         displayCoachData();

--- a/views/admin/doc.html
+++ b/views/admin/doc.html
@@ -46,7 +46,7 @@
 
 <div class="col-md-6">
     <h4>Overview of Runestone Directives</h4>
-    <p>This <a href="/runestone/static/overview/overview.html">Overview Page</a> Shows you all of the runestone
+    <p>This <a href="/{{=request.application}}/static/overview/overview.html">Overview Page</a> Shows you all of the runestone
         directives,
         along with the source. You may find this very useful for writing your own questions.</p>
 </div>

--- a/views/assignments/chooseAssignment.html
+++ b/views/assignments/chooseAssignment.html
@@ -2,12 +2,12 @@
 
 <h1>Assignments</h1>
 <table class="table table-striped">
-	<tr><th>Name</th><th>Due</th><th>Description</th></tr>
-	{{for assignment in assignments:}}
-		<tr>
-			<td><a href="doAssignment?assignment_id={{=assignment['id']}}">{{=assignment['name']}}</a></td>
-			<td>{{=assignment['duedate']}}</td>
-			<td>{{=assignment['description']}}</td>
-		</tr>
-	{{pass}}
+    <tr><th>Name</th><th>Due</th><th>Description</th></tr>
+    {{for assignment in assignments:}}
+        <tr>
+            <td><a href="doAssignment?assignment_id={{=assignment['id']}}">{{=assignment['name']}}</a></td>
+            <td>{{=assignment['duedate']}}</td>
+            <td>{{=assignment['description']}}</td>
+        </tr>
+    {{pass}}
 </table>

--- a/views/assignments/doAssignment.html
+++ b/views/assignments/doAssignment.html
@@ -46,12 +46,12 @@
 
 
 <script>
-	$('#hideId').css('display','none');
+    $('#hideId').css('display','none');
 </script>
 
 <script type="text/javascript">
   if(! eBookConfig) {
-	  eBookConfig = {};
+      eBookConfig = {};
   }
   eBookConfig.host = '';
   eBookConfig.app = eBookConfig.host+'/{{=request.application}}';
@@ -66,103 +66,104 @@
 </script>
 
 <style>
-	.completed {
-		list-style-image: url('/{{=request.application}}/static/{{=course_id}}/_static/completed.png');
-	}
-	.started {
-		list-style-type: circle;
-		list-style-image: url('/{{=request.application}}/static/{{=course_id}}/_static/active.png');
-	}
+    .completed {
+        list-style-image: url('/{{=request.application}}/static/{{=course_id}}/_static/completed.png');
+    }
+    .started {
+        list-style-type: circle;
+        list-style-image: url('/{{=request.application}}/static/{{=course_id}}/_static/active.png');
+    }
 </style>
 
 <div id='part1'>
-	<h1 style='text-align:center'>{{=assignment['name']}}</h1>
-	<h2 style='margin-left:1cm;'>Due: {{=assignment['duedate']}}</h2>
-		<span style="float:right; margin-right:1cm;">
-			Score: {{=questions_score+readings_score}} of {{=assignment['points']}}</span>
-	<div style='background-color:powderblue; margin-left:2cm; margin-right:2cm;'>
-		<p style='margin-left:0.5cm; margin-right:0.5cm;'>Description: {{=assignment['description']}}</p>
-	</div>
+    <h1 style='text-align:center'>{{=assignment['name']}}</h1>
+    <h2 style='margin-left:1cm;'>Due: {{=assignment['duedate']}}</h2>
+    <span style="float:right; margin-right:1cm;">
+        Score: {{=questions_score+readings_score}} of {{=assignment['points']}}
+    </span>
+    <div style='background-color:powderblue; margin-left:2cm; margin-right:2cm;'>
+        <p style='margin-left:0.5cm; margin-right:0.5cm;'>Description: {{=assignment['description']}}</p>
+    </div>
 
-	{{if len(readings) > 0:}}
-		<div id='readings' style='margin-left:15%;'>
-			<h3>Readings</h3>
-			<ul>
-				{{for reading in readings:}}
-					<li class='{{=readings[reading]['status']}}'>{{=reading}}</li>
-					<ul>
-					{{for r in readings[reading]['subchapters']:}}
-						<li class='{{=r['status']}}'><a href="/{{=request.application}}/static/{{=course_id}}/{{=r['chapter']}}/{{=r['subchapter']}}.html">{{=r['subchapter']}}</a>
-						{{if r['comment'] != 'ungraded':}}
-							</br>{{=r['score']}} of {{=r['points']}} points earned; minimum {{=r['activities_required']}} activities required
-						{{else:}}
-							</br>not graded yet: {{=r['points']}} points; minimum {{=r['activities_required']}} activities required
-						{{pass}}
-					</li>
+    {{if len(readings) > 0:}}
+        <div id='readings' style='margin-left:15%;'>
+            <h3>Readings</h3>
+            <ul>
+                {{for reading in readings:}}
+                    <li class='{{=readings[reading]['status']}}'>{{=reading}}</li>
+                    <ul>
+                    {{for r in readings[reading]['subchapters']:}}
+                        <li class='{{=r['status']}}'><a href="/{{=request.application}}/static/{{=course_id}}/{{=r['chapter']}}/{{=r['subchapter']}}.html">{{=r['subchapter']}}</a>
+                        {{if r['comment'] != 'ungraded':}}
+                            </br>{{=r['score']}} of {{=r['points']}} points earned; minimum {{=r['activities_required']}} activities required
+                        {{else:}}
+                            </br>not graded yet: {{=r['points']}} points; minimum {{=r['activities_required']}} activities required
+                        {{pass}}
+                    </li>
 
-					{{pass}}
-					</ul>
-				{{pass}}
-			</ul>
-		</div>
-	{{pass}}
+                    {{pass}}
+                    </ul>
+                {{pass}}
+            </ul>
+        </div>
+    {{pass}}
 
-	{{if len(questioninfo) > 0:}}
-		<div id='questions' style='margin-left:15%;'>
-		<h3>Questions</h3>
-			{{count=0}}
-			{{for q in questioninfo:}}
-					{{ if q['comment'] != 'ungraded':}}
-						<div style='float:right; width:30%;'>
-						<h4 style='text-align:center;'>Score: {{=q['score']}} / {{=q['points']}}</h4>
-						<p style='margin-left:2%;'>Comment: {{=q['comment']}}</p>
-						</div>
-					{{ else: }}
-						<div style='float:right; width:10%;'>
-						<h5 style='text-align:center;'>Not yet graded</h5>
-						</div>
-					{{pass}}
-					<span><div class='oneq' id='{{=count}}' style='width:90%;'>
-						<script class='htmlblock' type='text/html'>{{=q['htmlsrc']}}</script>
-					</div></span>
+    {{if len(questioninfo) > 0:}}
+        <div id='questions' style='margin-left:15%;'>
+        <h3>Questions</h3>
+            {{count=0}}
+            {{for q in questioninfo:}}
+                    {{ if q['comment'] != 'ungraded':}}
+                        <div style='float:right; width:30%;'>
+                        <h4 style='text-align:center;'>Score: {{=q['score']}} / {{=q['points']}}</h4>
+                        <p style='margin-left:2%;'>Comment: {{=q['comment']}}</p>
+                        </div>
+                    {{ else: }}
+                        <div style='float:right; width:10%;'>
+                        <h5 style='text-align:center;'>Not yet graded</h5>
+                        </div>
+                    {{pass}}
+                    <span><div class='oneq' id='{{=count}}' style='width:90%;'>
+                        <script class='htmlblock' type='text/html'>{{=q['htmlsrc']}}</script>
+                    </div></span>
 
-				{{count += 1}}
-			{{pass}}
-	
-		</div>
-	{{pass}}
+                {{count += 1}}
+            {{pass}}
+
+        </div>
+    {{pass}}
 </div>
 
 <script>
-	//console.log(document.getElementsByClassName('nav nav-tabs'))
-	// This script renders the html into elements in the DOM
-	// The html gets thrown into a script tag so javascript can mess with it without throwing errors all over the place
-	
-
-	var questionHtmlCode = document.getElementsByClassName("htmlblock");
-	// Interestingly, javascript won't understand the html string without first dumping it into an html element
-	// a console.log of the html string within the questioninfo array would only give an unexpected token error
-	// pulling the html strings from the script element provides the string that javascript recognizes
-	// even after stringifying the json.dumps version of a dictionary with the html as a value and then parsing the result, the html string was still seen as an undefined type according to javascript
-
-	// The htmlDecode is needed to unescape the html that the server has sent. 
-	// because only unescaped html gets rendered as html elements
-
-	function htmlDecode(input){
-  		let e = document.createElement('div');
-  		e.innerHTML = input;
-  		return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
-	}
-
-	
+    //console.log(document.getElementsByClassName('nav nav-tabs'))
+    // This script renders the html into elements in the DOM
+    // The html gets thrown into a script tag so javascript can mess with it without throwing errors all over the place
 
 
-	for (let i=0; i<questionHtmlCode.length; i++) {
-		let $div = $('#' + i);
-		let unescapedhtml = htmlDecode(questionHtmlCode[i].innerHTML);
-		let change = $.parseHTML(unescapedhtml, keepScripts=true);
-		$div.append(change);
-	}
+    var questionHtmlCode = document.getElementsByClassName("htmlblock");
+    // Interestingly, javascript won't understand the html string without first dumping it into an html element
+    // a console.log of the html string within the questioninfo array would only give an unexpected token error
+    // pulling the html strings from the script element provides the string that javascript recognizes
+    // even after stringifying the json.dumps version of a dictionary with the html as a value and then parsing the result, the html string was still seen as an undefined type according to javascript
+
+    // The htmlDecode is needed to unescape the html that the server has sent.
+    // because only unescaped html gets rendered as html elements
+
+    function htmlDecode(input){
+          let e = document.createElement('div');
+          e.innerHTML = input;
+          return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
+    }
+
+
+
+
+    for (let i=0; i<questionHtmlCode.length; i++) {
+        let $div = $('#' + i);
+        let unescapedhtml = htmlDecode(questionHtmlCode[i].innerHTML);
+        let change = $.parseHTML(unescapedhtml, keepScripts=true);
+        $div.append(change);
+    }
 
 
 </script>

--- a/views/assignments/index.html
+++ b/views/assignments/index.html
@@ -2,128 +2,125 @@
 <link rel="stylesheet" type="text/css" href="{{=URL('static', 'dashboard.css')}}"/>
 
 <div id="dashboard">
-	<h1>{{=student.first_name}} {{=student.last_name}}</h1>
-	<h2>Student Progress for {{=course_name}}</h2>
-	<div class="col-md-7">
-
-		<div class="dash-section">
-			<div class="dash-section-header">
-				Grades
-			</div>
-            {{ if practice_graded == 1: }}
-			<div class="dash-section-content scroll">
-             {{ if practice_message1 != "": }}
-                 <p>{{=practice_message1}}</p>
-                 <p>{{=practice_message2}}</p>
-             {{else:}}
-                 {{ if spacing == 1: }}
-                     {{ if practice_today_left > 0: }}
-                        <p>{{=practice_today_left}} question{{='' if practice_today_left == 1 else 's'}} left to get
-                            today's point of practicing.
-                        </p>
-                     {{ else: }}
-                        <p>You've already got today's point of practicing.</p>
-                     {{ pass }}
-                     <p>So far, you've received {{=points_received}} point{{='' if points_received == 1 else 's'}} out
-                         of {{=total_possible_points}} possible point{{='' if total_possible_points == 1 else 's'}} for
-                         completing {{=practice_completion_count}} day{{='' if practice_completion_count == 1 else 's'}}
-                         out of {{=max_days}} days of your review practice.
-                     </p>
-                 {{ else: }}
-                     <p>So far, you've received {{=points_received}} point{{='' if points_received == 1 else 's'}} out
-                         of {{=total_possible_points}} possible point{{='' if total_possible_points == 1 else 's'}} for
-                         answering {{=practice_completion_count}}
-                         question{{='' if practice_completion_count == 1 else 's'}} out
-                         of {{=max_questions}} questions to complete your practice.
-                         </p>
-                 {{ pass }}
-                 {{ if remaining_days > 0: }}
-                    <p>{{=remaining_days}} days are remaining to the end of the practicing period this semester.</p>
-                 {{ else: }}
-                    <p>The practicing period this semester is over, though you can continue practicing
-                        without receiving any extra points.
-                    </p>
-                 {{ pass }}
-             {{ pass }}
+    <h1>{{=student.first_name}} {{=student.last_name}}</h1>
+    <h2>Student Progress for {{=course_name}}</h2>
+    <div class="col-md-7">
+        <div class="dash-section">
+            <div class="dash-section-header">
+                Grades
             </div>
+            {{ if practice_graded == 1: }}
+                <div class="dash-section-content scroll">
+                    {{ if practice_message1 != "": }}
+                        <p>{{=practice_message1}}</p>
+                        <p>{{=practice_message2}}</p>
+                    {{else:}}
+                        {{ if spacing == 1: }}
+                            {{ if practice_today_left > 0: }}
+                                <p>{{=practice_today_left}} question{{='' if practice_today_left == 1 else 's'}} left to get
+                                    today's point of practicing.
+                                </p>
+                            {{ else: }}
+                                <p>You've already got today's point of practicing.</p>
+                            {{ pass }}
+                            <p>So far, you've received {{=points_received}} point{{='' if points_received == 1 else 's'}} out
+                                of {{=total_possible_points}} possible point{{='' if total_possible_points == 1 else 's'}} for
+                                completing {{=practice_completion_count}} day{{='' if practice_completion_count == 1 else 's'}}
+                                out of {{=max_days}} days of your review practice.
+                            </p>
+                        {{ else: }}
+                            <p>So far, you've received {{=points_received}} point{{='' if points_received == 1 else 's'}} out
+                                of {{=total_possible_points}} possible point{{='' if total_possible_points == 1 else 's'}} for
+                                answering {{=practice_completion_count}}
+                                question{{='' if practice_completion_count == 1 else 's'}} out
+                                of {{=max_questions}} questions to complete your practice.
+                                </p>
+                        {{ pass }}
+                        {{ if remaining_days > 0: }}
+                            <p>{{=remaining_days}} days are remaining to the end of the practicing period this semester.</p>
+                        {{ else: }}
+                            <p>The practicing period this semester is over, though you can continue practicing
+                               without receiving any extra points.
+                            </p>
+                        {{ pass }}
+                    {{ pass }}
+                </div>
             {{ pass }}
             <div class="dash-section-content scroll">
-				<table width="90%">
-					<thead>
-						<tr>
-							<td>Assignment</td>
-							<td>Due Date</td>
-							<td>Grade</td>
-							<td>Average</td>
-						</tr>
-					</thead>
-					<tbody>
-						{{ for k in sorted(assignments.keys()): }}
-						<tr>
-							<td>{{=k}}</td>
-							<td>{{=assignments[k]["due_date"]}}</td>
-							<td>{{=assignments[k]["score"]}}</td>
-							<td>{{=assignments[k]["class_average"]}}</td>
-						</tr>
-						{{ pass }}
-					</tbody>
-				</table>
-			</div>
-		</div>
-		<div class="dash-section" id="book-completion">
-			<div class="dash-section-header">
-				Book Completion
-			</div>
-			<div class="dash-section-content">
-				{{ for chapter in chapters: }}
-				<div class="chapter">
-					<div class="clickable {{=chapter['status']}}">
-						{{=chapter["label"]}}
-						<div class="collapse-icon"></div>
-					</div>
-					<div class="chapter-detail dhide">
-						{{ for subchapter in chapter["subchapters"]: }}
-						<div class="{{=subchapter['status']}}">{{=subchapter["label"]}}
-						</div>
-						{{ pass }}
-					</div>
-				</div>
-				{{ pass }}
-				<script>
-				$(".chapter .clickable").click(function(){
-					$(this).toggleClass("expanded")
-					$(this).parent().children(".chapter-detail").toggleClass("dhide");
-				});
-				</script>
-			</div>
-		</div>
-	</div>
-	<div class="col-md-5">
-		<div class="dash-section">
-			<div class="dash-section-header">
-				Profile
-			</div>
-			<div class="dash-section-content">
-				<div>Username: {{=user.username}}</div>
-				<div>Email: {{=user.email}}</div>
-			</div>
-		</div>
-		<div class="dash-section">
-			<div class="dash-section-header">
-				Recent Activity
-			</div>
-			<div class="dash-section-content scroll">
-				<table class="nodec">
-					{{for row in activity:}}
-					<tr>
-						<td>{{=row["event"]}}</td>
-						<td>{{=row["time"]}}</td>
-					</tr>
-					{{pass}}
-				</table>
-			</div>
-		</div>
-	</div>
+                <table style="width: 90%">
+                    <thead>
+                        <tr>
+                            <td>Assignment</td>
+                            <td>Due Date</td>
+                            <td>Grade</td>
+                            <td>Average</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{ for k in sorted(assignments.keys()): }}
+                            <tr>
+                                <td>{{=k}}</td>
+                                <td>{{=assignments[k]["due_date"]}}</td>
+                                <td>{{=assignments[k]["score"]}}</td>
+                                <td>{{=assignments[k]["class_average"]}}</td>
+                            </tr>
+                        {{ pass }}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="dash-section" id="book-completion">
+            <div class="dash-section-header">
+                Book Completion
+            </div>
+            <div class="dash-section-content">
+                {{ for chapter in chapters: }}
+                    <div class="chapter">
+                        <div class="clickable {{=chapter['status']}}">
+                            {{=chapter["label"]}}
+                            <div class="collapse-icon"></div>
+                        </div>
+                        <div class="chapter-detail dhide">
+                            {{ for subchapter in chapter["subchapters"]: }}
+                                <div class="{{=subchapter['status']}}">{{=subchapter["label"]}}
+                                </div>
+                            {{ pass }}
+                        </div>
+                    </div>
+                {{ pass }}
+                <script>
+                $(".chapter .clickable").click(function(){
+                    $(this).toggleClass("expanded")
+                    $(this).parent().children(".chapter-detail").toggleClass("dhide");
+                });
+                </script>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-5">
+        <div class="dash-section">
+            <div class="dash-section-header">
+                Profile
+            </div>
+            <div class="dash-section-content">
+                <div>Username: {{=user.username}}</div>
+                <div>Email: {{=user.email}}</div>
+            </div>
+        </div>
+        <div class="dash-section">
+            <div class="dash-section-header">
+                Recent Activity
+            </div>
+            <div class="dash-section-content scroll">
+                <table class="nodec">
+                    {{for row in activity:}}
+                        <tr>
+                            <td>{{=row["event"]}}</td>
+                            <td>{{=row["time"]}}</td>
+                        </tr>
+                    {{pass}}
+                </table>
+            </div>
+        </div>
+    </div>
 </div>
-{{ pass }}  <!-- end loop over types -->
-</div><!-- end #assignments -->

--- a/views/assignments/practice.html
+++ b/views/assignments/practice.html
@@ -48,12 +48,12 @@
 
 
 <script>
-	$('#hideId').css('display','none');
+    $('#hideId').css('display','none');
 </script>
 
 <script type="text/javascript">
   if(! eBookConfig) {
-	  eBookConfig = {};
+      eBookConfig = {};
   }
   eBookConfig.host = '';
   eBookConfig.app = eBookConfig.host+'/{{=request.application}}';
@@ -69,13 +69,13 @@
 </script>
 
 <style>
-	.completed {
-		list-style-image: url('/{{=request.application}}/static/{{=course_id}}/_static/completed.png');
-	}
-	.started {
-		list-style-type: circle;
-		list-style-image: url('/{{=request.application}}/static/{{=course_id}}/_static/active.png');
-	}
+    .completed {
+        list-style-image: url('/{{=request.application}}/static/{{=course_id}}/_static/completed.png');
+    }
+    .started {
+        list-style-type: circle;
+        list-style-image: url('/{{=request.application}}/static/{{=course_id}}/_static/active.png');
+    }
     .NextQuestionAnchor {
         font-size: 19px;
     }
@@ -182,7 +182,7 @@
 </script>
 
 <div id='part1' style="padding-left: 40px">
-	<h1 style='text-align:center'>Review Practice Questions</h1>
+    <h1 style='text-align:center'>Review Practice Questions</h1>
     <div class="alert alert-danger" style="margin-right: 40px;">
          {{ if flashcard_count > 1: }}
              {{ if spacing == 1: }}
@@ -399,9 +399,9 @@
 </div>
 
 <script>
-	//console.log(document.getElementsByClassName('nav nav-tabs'))
-	// This script renders the html into elements in the DOM
-	// The html gets thrown into a script tag so javascript can mess with it without throwing errors all over the place
+    //console.log(document.getElementsByClassName('nav nav-tabs'))
+    // This script renders the html into elements in the DOM
+    // The html gets thrown into a script tag so javascript can mess with it without throwing errors all over the place
 
 {{ if flashcard_count > 0: }}
     $(window).on('load', function (e) {
@@ -460,23 +460,23 @@
     });
 {{ pass }}
 {{ if practice_today_left > 0 or q: }}
-	var questionHtmlCode = document.getElementById("htmlblock");
-	// Interestingly, javascript won't understand the html string without first dumping it into an html element
-	// a console.log of the html string within the questioninfo array would only give an unexpected token error
-	// pulling the html strings from the script element provides the string that javascript recognizes
-	// even after stringifying the json.dumps version of a dictionary with the html as a value and then parsing the
+    var questionHtmlCode = document.getElementById("htmlblock");
+    // Interestingly, javascript won't understand the html string without first dumping it into an html element
+    // a console.log of the html string within the questioninfo array would only give an unexpected token error
+    // pulling the html strings from the script element provides the string that javascript recognizes
+    // even after stringifying the json.dumps version of a dictionary with the html as a value and then parsing the
     // result, the html string was still seen as an undefined type according to javascript
 
-	// The htmlDecode is needed to unescape the html that the server has sent.
-	// because only unescaped html gets rendered as html elements
+    // The htmlDecode is needed to unescape the html that the server has sent.
+    // because only unescaped html gets rendered as html elements
 
-	function htmlDecode(input){
-  		let e = document.createElement('div');
-  		e.innerHTML = input;
-  		return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
-	}
+    function htmlDecode(input){
+          let e = document.createElement('div');
+          e.innerHTML = input;
+          return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
+    }
 
-	let $div = $("#QuestionContainer");
+    let $div = $("#QuestionContainer");
     let unescapedhtml = htmlDecode(questionHtmlCode.innerHTML);
     let change = $.parseHTML(unescapedhtml, keepScripts=true);
     $div.append(change);

--- a/views/dashboard/grades.html
+++ b/views/dashboard/grades.html
@@ -15,7 +15,7 @@
 
 <div id="dashboard">
 	<h1>{{=course_name}}</h1>
-	<h2>Gradebook</h2> 
+	<h2>Gradebook</h2>
 	<div>
 		<label for="studentsearch">Filter by Student</label>
 		<input type="text" id="studentsearch" onkeyup="searchStudent()" placeholder="Name of student..">
@@ -43,7 +43,7 @@
 			</thead>
 
 			<tbody>
-				<tr bgcolor="lightgray" id="classaverage">
+				<tr style="background-color: lightgray" id="classaverage">
 					<td>Class Average</td>
 					<td> </td>
 					<td> </td>
@@ -100,7 +100,7 @@
 		      	} else {
 		        	tr[i].style.display = "none";
 		      	}
-		  	}       
+		  	}
 		}
 	}
 
@@ -118,18 +118,18 @@
 	    		// Because sorting adds a span to the innerHTML of the head td's
 	    		rogue = tablehead[i].innerHTML.split('<span id="sorttable_sort');
 	    		console.log(rogue[0])
-		    	tds = document.getElementsByClassName(rogue[0]); 
+		    	tds = document.getElementsByClassName(rogue[0]);
 		    	if (tablehead[i].innerHTML.toUpperCase().indexOf(filter) > -1) {
 		    		tablehead[i].style.display = "";
 		    		for (j = 0; j < tds.length; j ++) {
 		    			tds[j].style.display = "";
 		    		}
-			    	
+
 		    	} else {
 		    		tablehead[i].style.display = "none";
 		    		for (j = 0; j < tds.length; j ++) {
 		    			tds[j].style.display = "none";
-		    		}	
+		    		}
 		    	}
 		    }
 	    }

--- a/views/default/courses.html
+++ b/views/default/courses.html
@@ -6,18 +6,18 @@
 
 <div class=".container">
     <div style="text-align:center;">
-        
+
         <h1>Course Selection</h1>
         <p>Choose your course. If you want to add a new course, click "Add Another Course" then change the course name in your profile.</p>
 {{ for course in courses: }}
-            <form action="/runestone/default/coursechooser/{{=course}}" method="post">
+            <form action="/{{=request.application}}/default/coursechooser/{{=course}}" method="post">
             <button class="ac_opt btn btn-default book-btn" type="submit" name=course value={{=course}} style="font-size: 16pt;">{{=course}}</button><br/>
             </form>
 {{pass}}
-        <form action="/runestone/default/user/profile">
+        <form action="/{{=request.application}}/default/user/profile">
             <button class="ac_opt btn btn-default course-btn" style="font-size: 16pt;">Add Another Course</button>
         </form>
-        <form action="/runestone/default/remove" method="post">
+        <form action="/{{=request.application}}/default/remove" method="post">
         <button class="ac_opt btn btn-default course-btn" name="remove" type="submit" style="font-size: 16pt;">Remove a Course</button>
         </form>
 

--- a/views/default/donate.html
+++ b/views/default/donate.html
@@ -75,9 +75,9 @@
 
                 // The payment is complete!
                 // You can now show a confirmation message to the customer
-            $.get("/runestone/ajax/save_donate")
+            $.get("/{{=request.application}}/ajax/save_donate")
             alert('Payment successful - Thank you! ')
-            window.location.href = "/runestone/default"
+            window.location.href = "/{{=request.application}}/default"
             });
       },
 

--- a/views/default/remove.html
+++ b/views/default/remove.html
@@ -12,11 +12,11 @@
 <div class=".container">
   <div style="text-align: center">
   {{for course in courses:}}
-    <form action="/runestone/default/removecourse/{{=course}}" class="course-form" method="post" onsubmit="return confirm('Are you sure you want to delete this course? (Courses can be added back in the user profile)')">
+    <form action="/{{=request.application}}/default/removecourse/{{=course}}" class="course-form" method="post" onsubmit="return confirm('Are you sure you want to delete this course? (Courses can be added back in the user profile)')">
       <button class="ac_opt btn btn-default book-btn" name="course" type="submit" value={{=course}} style="font-size: 16pt;">{{=course}}</button>
     </form>
   {{pass}}
-  <form action="/runestone/default/courses" class="course-form" method="post">
+  <form action="/{{=request.application}}/default/courses" class="course-form" method="post">
     <button class="ac_opt btn btn-default course-btn" name="goback" type="submit" style="font-size: 16pt;">Go Back</button>
   </form>
 

--- a/views/default/user.html
+++ b/views/default/user.html
@@ -21,7 +21,7 @@
         <div class="row">
             <!-- Carousel
             ================================================== -->
-            <link href="/runestone/static/css/carousel.css" rel="stylesheet">
+            <link href="/{{=request.application}}/static/css/carousel.css" rel="stylesheet">
             <div class="carousel slide col-md-8" data-ride="carousel" id="myCarousel">
                 <!-- Indicators -->
                 <ol class="carousel-indicators">

--- a/views/layout.html
+++ b/views/layout.html
@@ -206,7 +206,7 @@
                 <p>
                     &copy; Copyright 2018 Runestone Interactive LLC
                     {{ if settings.academy_mode: }}
-                        &emsp; ● <a href="/runestone/default/privacy">Privacy Policy</a> &emsp; ●  <a href="/runestone/default/terms">Terms of Service</a>
+                        &emsp; ● <a href="/{{=request.application}}/default/privacy">Privacy Policy</a> &emsp; ●  <a href="/{{=request.application}}/default/terms">Terms of Service</a>
                     {{ pass }}
                 </p>
             </div>

--- a/views/oauth/index.html
+++ b/views/oauth/index.html
@@ -2,7 +2,7 @@
 
 
 
-This page is a utility for accepting redirects from external services like Spotify or LinkedIn that use oauth. You should have reached this page after authorizing at one of those sites.</br></br>
+This page is a utility for accepting redirects from external services like Spotify or LinkedIn that use oauth. You should have reached this page after authorizing at one of those sites.<br><br>
 
 Normally, you will have reached this site with a python program running on your computer wait for you to paste in the url for this page, which is also printed below. Copy it and paste it into the terminal window where that program is running.
 


### PR DESCRIPTION
This PR contains a revamped pytest approach with fixtures for most basic operations. In addition:

- A minor tweak to the server to support testing.
- More HTML fixes to pass validation tests.
- Changes to avoid hardcoding the application as 'runestone' where possible. There are still more places where this could be done. I run an exam_runestone application to give tests, which has a different setup than my usual runestone application where I assign homework.

To verify this last change, I ran the tests before commit 35f21a7f5c81f9cc60f85a65e2805c784c3db5fe, then ran them again after that commit and compared differences in the generated HTML based on these additions to `test_server.py` starting at line 189:

``` Python
                # TODO: Remove this. It checks that the HTML generated doesn't change.
                from difflib import unified_diff
                file_name = url.replace('/', '-') + '.html'
                try:
                    with open(file_name, 'rb') as f:
                        # Remove the CSRF tag, which differs.
                        old_text = [x for x in f.read().splitlines() if '<input name="_formkey" type="hidden" value="' not in x]
                        new_text = [x for x in self.text.splitlines() if '<input name="_formkey" type="hidden" value="' not in x]
                        if ''.join(old_text) != ''.join(new_text):
                            with open(file_name + '.diff.html', 'wb') as g:
                                g.write('\n'.join(unified_diff(new_text, old_text)))
                            assert False
                except IOError:
                    with open(file_name, 'wb') as f:
                        f.write(self.text)
```