### PR TITLE
Fix: Clean up the section name in the default/user/profile file.

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -5,7 +5,9 @@ import requests
 from urllib import unquote
 from urllib2 import HTTPError
 import logging
+
 from gluon.restricted import RestrictedError
+from gluon.tools import addrow
 
 logger = logging.getLogger(settings.logger)
 logger.setLevel(settings.log_level)
@@ -62,9 +64,16 @@ def user():
             sectname = sectname.name
         else:
             sectname = 'default'
-        my_extra_element = TR(LABEL('Section Name'),
-                              INPUT(_name='section', value=sectname, _type='text'))
-        form[0].insert(-1, my_extra_element)
+        # Add the section. Taken from ``gluon.tools.addrow`` where ``style='table3cols'``.
+        form[0].insert(-1,
+            TR(
+                TD(LABEL('Section Name: ', _for='auth_user_section', _id='auth_user_section__label'), _class='w2p_fl'),
+                TD(INPUT(_name='section', _type='text', _value=sectname, _id='auth_user_section', _class='string'), _class='w2p_fw'),
+                TD('', _class='w2p_fc'),
+                _id='auth_user_section__row',
+            )
+        )
+        # Make the username read-only.
         form.element('#auth_user_username')['_readonly'] = True
 
     if 'profile' in request.args(0):


### PR DESCRIPTION
A typical entry for another field in the `default/user/profile` form:
``` HTML
<tr id="auth_user_first_name__row">
    <td class="w2p_fl">
        <label class="" for="auth_user_first_name" id="auth_user_first_name__label">First Name: </label>
    </td>
    <td class="w2p_fw">
        <input class="string" id="auth_user_first_name" name="first_name" type="text" value="test" />
    </td>
    <td class="w2p_fc"></td>
</tr>
```

Before this PR, the "Section Name" looked like this:
``` HTML
<tr>
    <td>
        <label>Section Name</label>
    </td>
    <td>
        <input name="section" type="text" value="default" />
    </td>
</tr>
```

After this PR, it matches other fields:
``` HTML
<tr id="auth_user_section__row">
    <td class="w2p_fl">
        <label for="auth_user_section" id="auth_user_section__label">Section Name: </label>
    </td>
    <td class="w2p_fw">
        <input class="string" id="auth_user_section" name="section" type="text" value="default" />
    </td>
    <td class="w2p_fc"></td>
</tr>
```