### PR TITLE
Fix validation

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -367,8 +367,7 @@ def test_user_1(runestone_db_tools, test_user):
 
     # Assignments
     ('assignments/index', True, 'Student Progress for', 1),
-    # FIXME: There's a duplicated id ``fb-root`` on this page.
-    ('assignments/practice', True, 'Practice tool is not set up for this course yet.', 2),
+    ('assignments/practice', True, 'Practice tool is not set up for this course yet.', 1),
     ('assignments/chooseAssignment', True, 'Assignments', 1),
 
     # Misc

--- a/views/assignments/practice.html
+++ b/views/assignments/practice.html
@@ -169,18 +169,6 @@
     }
 </style>
 
-<!--Facebook Comments plugin script-->
-<div id="fb-root"></div>
-<script>
-    (function(d, s, id) {
-      var js, fjs = d.getElementsByTagName(s)[0];
-      if (d.getElementById(id)) return;
-      js = d.createElement(s); js.id = id;
-      js.src = 'https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v2.11';
-      fjs.parentNode.insertBefore(js, fjs);
-    }(document, 'script', 'facebook-jssdk'));
-</script>
-
 <div id='part1' style="padding-left: 40px">
     <h1 style='text-align:center'>Review Practice Questions</h1>
     <div class="alert alert-danger" style="margin-right: 40px;">

--- a/views/assignments/practiceNotStartedYet.html
+++ b/views/assignments/practiceNotStartedYet.html
@@ -48,22 +48,7 @@
 
 
 <script>
-	$('#hideId').css('display','none');
-</script>
-
-<style>
-</style>
-
-<!--Facebook Comments plugin script-->
-<div id="fb-root"></div>
-<script>
-    (function(d, s, id) {
-      var js, fjs = d.getElementsByTagName(s)[0];
-      if (d.getElementById(id)) return;
-      js = d.createElement(s); js.id = id;
-      js.src = 'https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v2.11';
-      fjs.parentNode.insertBefore(js, fjs);
-    }(document, 'script', 'facebook-jssdk'));
+    $('#hideId').css('display','none');
 </script>
 
 <div id='part1' style="padding-left: 40px">

--- a/views/default/privacy.html
+++ b/views/default/privacy.html
@@ -3,26 +3,29 @@
 {{block statusbar}}
 {{end}}
 
-<style>
-    #ppBody {
-        font-size: 14pt;
-        font-family: sans-serif;
-        width: 80%;
-        margin: 0 auto;
-        text-align: justify;
-    }
+{{block moreincludes}}
+    <style>
+        #ppBody {
+            font-size: 14pt;
+            font-family: sans-serif;
+            width: 80%;
+            margin: 0 auto;
+            text-align: justify;
+        }
 
-    #ppHeader {
-        font-family: verdana sans-serif;
-        font-size: 24pt;
-        width: 80%;
-        margin: 0 auto;
-    }
+        #ppHeader {
+            font-family: verdana sans-serif;
+            font-size: 24pt;
+            width: 80%;
+            margin: 0 auto;
+        }
 
-    .ppConsistencies {
-        display: none;
-    }
-</style>
+        .ppConsistencies {
+            display: none;
+        }
+    </style>
+{{end}}
+
 <div id='ppHeader'>Runestone Academy Privacy Policy</div>
 
 <div id='ppBody'>
@@ -172,8 +175,8 @@
     </div><br>
     <div class="innterText">
         <strong>YouTube Videos</strong> -- We use YouTube to host the videos contained in our textbooks because it is economical
-         and the most reliable way to ensure that we can serve videos on as many browsers on as many platforms 
-         as possible. When we use YouTube for videos then you should understand that 
+         and the most reliable way to ensure that we can serve videos on as many browsers on as many platforms
+         as possible. When we use YouTube for videos then you should understand that
          YouTube's <a href="https://www.youtube.com/t/terms">Terms of Service</a> apply.
     </div>
     <span id='trLi'></span><br>
@@ -188,7 +191,7 @@
     <span id='gooAd'></span><br>
     <div class='blueText'><strong>Google</strong></div>
     <br/>
-    
+
         <div class='innerText'>Google's advertising requirements can be summed up by Google's Advertising Principles. They
             are put in place to provide a positive experience for users.
             https://support.google.com/adwordspolicy/answer/1316548?hl=en <br><br></div>

--- a/views/default/terms.html
+++ b/views/default/terms.html
@@ -2,15 +2,18 @@
 
 {{block statusbar}}
 {{end}}
-<style>
-    #ppBody {
-        font-size: 14pt;
-        font-family: sans-serif;
-        width: 80%;
-        margin: 0 auto;
-        text-align: justify;
-    }
-</style>
+
+{{block moreincludes}}
+    <style>
+        #ppBody {
+            font-size: 14pt;
+            font-family: sans-serif;
+            width: 80%;
+            margin: 0 auto;
+            text-align: justify;
+        }
+    </style>
+{{end}}
 
 <div id="ppBody">
     <h1>Terms and Conditions</h1>

--- a/views/default/user.html
+++ b/views/default/user.html
@@ -1,18 +1,19 @@
 {{user_navs = True}}
 {{extend 'layout.html'}}
 
+{{block moreincludes}}
     <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+    <style type="text/css">
+        .rscontainer {
+            padding-left: 20px;
+            padding-right:20px;
+            padding-top: 20px;
+        }
+    </style>
+{{end}}
 
 {{block statusbar}}
 {{end}}
-
-<style type="text/css">
-    .rscontainer {
-        padding-left: 20px;
-        padding-right:20px;
-        padding-top: 20px;
-    }
-</style>
 
 <div class="container rscontainer">
 


### PR DESCRIPTION
This corrects the test failures seen in recent PRs, such as #1159. I'm guessing the W3C validator changed, hence the failures. The changes consist of:

1. Move `<style>` tags into the `<head>` tag (see 96ca8e3ec8ec242bfb1368f2cad0fe6a0653e3bc).
2. Remove duplicate Facebooks scripts, since they're already present in [views\layout.html](https://github.com/RunestoneInteractive/RunestoneServer/blob/master/views/layout.html#L38). See 96ca8e3ec8ec242bfb1368f2cad0fe6a0653e3bc.
3. Update the tests, since this reduces the number of validation errors to ignore. See d65cf686694f5aafc7f6c2ea4ca24acc321ad5bb.

This should be merged before anything else, since otherwise the test suite will report errors unrelated to those PRs.