### PR TITLE
Registration fix

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -116,6 +116,16 @@ def user():
             # add a row to section_users for this user with the section selected.
             redirect(URL('default', 'index'))
 
+    if 'register' in request.args(0):
+        # The validation function ``IS_COURSE_ID`` in ``models/db.py`` changes the course name supplied to a course ID. If the overall form doesn't validate, the value when the form is re-displayed with errors will contain the ID instead of the course name. Change it back to the course name. Note: if the user enters a course for the course name, it will be displayed as the corresponding course name after a failed validation. I don't think this case is important enough to fix.
+        try:
+            course_id = int(form.vars.course_id)
+        except:
+            pass
+        else:
+            # Look up the course name based on the ID.
+            form.vars.course_id = getCourseNameFromId(course_id)
+
     # this looks horrible but it seems to be the only way to add a CSS class to the submit button
     try:
         form.element(_id='submit_record__row')[1][0]['_class'] = 'btn btn-default'

--- a/models/db.py
+++ b/models/db.py
@@ -103,8 +103,8 @@ db.define_table('cohort_master',
 def getCourseNameFromId(courseid):
     ''' used to compute auth.user.course_name field '''
     q = db.courses.id == courseid
-    course_name = db(q).select()[0].course_name
-    return course_name
+    row = db(q).select().first()
+    return row.course_name if row else ''
 
 
 def verifyInstructorStatus(course, instructor):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -511,3 +511,31 @@ def test_4(test_client, test_user_1):
         #assert user.section == section
 
         # TODO: Test for an error if ``email`` is invalid.
+
+# Test that the course name is correctly preserved across registrations if other fields are invalid.
+def test_5(test_client, runestone_db_tools):
+    # Registration doesn't work unless we're logged out.
+    test_client.logout()
+    course_name = 'a_course_name'
+    with runestone_db_tools.create_course(course_name) as course:
+        # Now, post the registration.
+        username = 'username'
+        first_name = 'first'
+        last_name = 'last'
+        email = 'e@mail.com'
+        password = 'password'
+        test_client.validate('default/user/register', 'Please fix the following errors in your registration', data=dict(
+            username=username,
+            first_name=first_name,
+            last_name=last_name,
+            # The e-mail address must be unique.
+            email=email,
+            password=password,
+            password_two=password + 'oops',
+            # Note that ``course_id`` is (on the form) actually a course name.
+            course_id=course_name,
+            accept_tcp='on',
+            donate='0',
+            _next='/runestone/default/index',
+            _formname='register',
+        ))


### PR DESCRIPTION
If a user makes a data entry error when registering (for example, the passwords don't match), then the course name they entered is replaced by the course ID from the database when the form is re-displayed with an error. This fix keeps the course name from being changed to a course ID. It also adds tests for this case.