### PR TITLE
Workaround: Never grade all problems for all students

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -155,16 +155,19 @@ function autoGrade() {
     }
 
     if (assignment != null && question === null && studentID == null) {
+        let i = 0;
         for (let s in students) {
             params.data.sid = s;
             params.async = false;
             let res = jQuery.ajax(params);
-            $("#autogradingform").append(`${res.responseJSON.message} for ${s} </br>`)
+            setTimeout(function(s) {
+                $("#autogradingform").append(`${res.responseJSON.message} for ${s} </br>`)
+            }, 10, s);
         }
         calculateTotals();
         $("#autogradesubmit").prop("disabled", false);
     } else {
-        jquery.axax(params).always(function () {
+        jQuery.ajax(params).always(function () {
             calculateTotals();
             $("#autogradesubmit").prop("disabled", false);
         });

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -138,7 +138,7 @@ function autoGrade() {
     var question = getSelectedItem("question")
     var studentID = getSelectedItem("student")
     var enforceDeadline = $('#enforceDeadline').is(':checked')
-    jQuery.ajax({
+    var params = {
         url: eBookConfig.autogradingURL,
         type: "POST",
         dataType: "JSON",
@@ -150,12 +150,26 @@ function autoGrade() {
         },
         success: function (retdata) {
             $('#assignmentTotalform').css('visibility', 'hidden');
-            calculateTotals();
-            alert(retdata.message);
+            //alert(retdata.message);
         }
-    }).always(function () {
+    }
+
+    if (assignment != null && question === null && studentID == null) {
+        for (let s in students) {
+            params.data.sid = s;
+            params.async = false;
+            let res = jQuery.ajax(params);
+            $("#autogradingform").append(`${res.responseJSON.message} for ${s} </br>`)
+        }
+        calculateTotals();
         $("#autogradesubmit").prop("disabled", false);
-    });
+    } else {
+        jquery.axax(params).always(function () {
+            calculateTotals();
+            $("#autogradesubmit").prop("disabled", false);
+        });
+    }
+
 }
 
 function calculateTotals(sid) {
@@ -1323,7 +1337,7 @@ function assignmentInfo() {
             // Put the qeustion in the table.
             let name = question['name'];
             allQuestions.push(createQuestionObject(name, question['points'], question['autograde'], question['autograde_possible_values'], question['which_to_grade'], question['which_to_grade_possible_values']));
-            // Check this question in the question tree picker.  
+            // Check this question in the question tree picker.
             // Assumes that the picker tree is built before we do this loop.
             tqp.check_node(tqp.get_node(name));
         }


### PR DESCRIPTION
@presnick , @bjones1 

This change was inspired by a hack published by one of our professors.  

It subverts grading ALL problems for ALL students when just the assignment is selected.  The underlying problem is that autograde is too slow for large classes or large assignments, but this gets around the problem by grading one student at a time.

I think its better than letting the majority of users suffer.

Comments?