### PR TITLE
WiP: Dockerfile for turnkey deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+FROM debian:stretch-backports
+MAINTAINER Yaroslav O. Halchenko <debian@onerussian.com>
+
+ARG WEB2PY_PATH=/srv/web2py
+ARG WEB2PY_APPS_PATH=${WEB2PY_PATH}/applications
+
+# TODO: Figure out the whole desired setup.  
+#  - Books probably should live outside an be bind mounted inside (/srv/runstone/books?)
+#  - or may be the entire server be bind mounted from outside?
+
+# TODO: convert generation to neurodocker call after all is cool
+
+# To prevent interactive debconf during installations
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y eatmydata
+
+RUN eatmydata apt-get update && echo "count 1" && \
+    eatmydata apt-get install -y --no-install-recommends \
+        git \
+        python-pip libfreetype6-dev postgresql-common postgresql postgresql-contrib \
+        libpq-dev libxml2-dev libxslt1-dev
+
+# Components from requirements.txt which are available in Debian
+# Missing ones:
+#  runestone -- is the RunestoneComponents, https://pypi.org/project/runestone/, may be install from Git?
+#  paver -- too old in Debian  filed bug report
+#  selenium -- also a bit too old (2.53.2+dfsg1-1)
+#  sphinxcontrib-paverutils -- N/A
+#  sphinx -- we need stretch-backports
+#  pytz ... ?
+RUN eatmydata apt-get install -y --no-install-recommends \
+        python-diff-match-patch \
+        python-lxml \
+        python-numpy \
+        python-numpy \
+        python-psycopg2 \
+        pylint \
+        python-dateutil \
+        python-requests \
+        python-selenium \
+        python-six \
+        python-sphinx \
+        python-sqlalchemy \
+        python-cssselect \
+        python-oauth2client
+    
+
+# Install additional components
+RUN git clone --recursive https://github.com/web2py/web2py /usr/local/lib/web2py && \
+    ln -s /usr/local/lib/web2py/web2py.py /usr/local/bin/web2py.py
+
+RUN mkdir -p ${WEB2PY_APPS_PATH} && \
+    cd ${WEB2PY_APPS_PATH} && \
+    git clone https://github.com/RunestoneInteractive/RunestoneServer runestone
+
+# A few missing ones
+RUN eatmydata apt-get install -y --no-install-recommends \
+        python-wheel
+
+RUN cd ${WEB2PY_APPS_PATH}/runestone && \
+    pip install -r requirements.txt
+    
+
+#RUN apt-get clean

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# TODO - this location also allow to do needed copying etc to keep DB outside as well
+stamp=/var/lib/postgresql/9.6/main/initialized.stamp
+
+# Fail early upon error
+set -eu
+
+info () {
+    echo "I: $@"
+}
+
+# Start service(s)
+info "Starting the DB server"
+service postgresql start
+trap "service postgresql stop" 0
+
+export WEB2PY_CONFIG=production
+export WEB2PY_MIGRATE=Yes
+export DBURL=postgresql://runestone:${DB_PASSWORD}@localhost/runestone
+
+if [ ! -e "$stamp" ]; then
+    info "Initializing"
+    su -c "psql postgres -c \"CREATE USER runestone superuser password '${DB_PASSWORD}';\"" postgres
+    su -c "createdb --owner=runestone runestone" postgres
+    cd "$BOOKS_PATH/.."
+    su -c "rsmanage initdb" runestone
+    cp $WEB2PY_PATH/applications/runestone/scripts/run_scheduler.py $WEB2PY_PATH/
+    # Let's use https
+    echo -e '\nsettings.server_type = "https://"' >> $WEB2PY_PATH/applications/runestone/models/0.py
+    touch "$stamp"
+else
+    info "Already initialized"
+fi
+
+# Go through all books and do what needs to be done
+info "Building & Deploying books"
+cd "${BOOKS_PATH}"
+/bin/ls | while read b; do
+    (
+        cd $b;
+        su -c "runestone build && runestone deploy" runestone;
+    );
+done
+
+# Run the beast
+info "Starting the server"
+cd "$WEB2PY_PATH"
+su -c "python web2py.py --ip=0.0.0.0 --port=8080 --password='$DB_PASSWORD' -K runestone --nogui -X" runestone  &
+sleep 3
+info "Starting the scheduler"
+su -c "python run_scheduler.py" runestone

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -26,8 +26,10 @@ if [ ! -e "$stamp" ]; then
     cd "$BOOKS_PATH/.."
     su -c "rsmanage initdb" runestone
     cp $WEB2PY_PATH/applications/runestone/scripts/run_scheduler.py $WEB2PY_PATH/
+
     # Let's use https
-    echo -e '\nsettings.server_type = "https://"' >> $WEB2PY_PATH/applications/runestone/models/0.py
+    # Wouldn't "just work" magically.  Requires certificates etc. Eventually!
+    # echo -e '\nsettings.server_type = "https://"' >> $WEB2PY_PATH/applications/runestone/models/0.py
     touch "$stamp"
 else
     info "Already initialized"


### PR DESCRIPTION
This is ATM just an initial version of Dockerfile which just installs needed components

Setup
- Have `books/` directory with books (due to #1180 I guess should only be known books)
- Optionally have `configs/{instructors,students}.csv` and bindmount that configs as `/srv/configs` to get DB populated and locked down
- Run docker with needed bind mounts and only a few options (e.g. DB password) to get the whole machinery setup and running
- Running container then should be cherished to not be gone, since it would contain built/deployed books and the active DB (see below may be about bind mounting DB itself)

TODOs
- [x] Add a `runestone` user and switch installation of all non-system wide components to be done under that user.  I guess the server could be ran under e.g. 8080 but port mapped by docker itself upon run to port 80
- [x] Decide on how to organize it for proper balance of flexibility (e.g. having books bind mountable outside, or in principle could be an `ARG` on which books to deploy)
- [ ] See if the entire beast could be RF'ed to be a neurodocker call, so it would be easy to generate also Singularity images and overall have a more concise recipe
- [ ] Consider versioning all git repos and use pipenv to create fixed tested server deployment.
- [x] Make its entry point to be the process to start the server
- [x] Minimize footprint by joining all apt calls, and doing proper cleanup after
- [ ] Someone who actually has a clue in DBA should look at the whole setup. To me, the "superuser" for the DB looks too dangerous
- [ ] Someone who actually has a clue in Docker should look at the Dockerfile and probably suggest a proper Docker compose recipe with 2 docker images, where DB will be provided by one and the whole app by another one talking to the DB in the first one
- [ ] I have looked into this **external db** and soon will push the version with some code for it. But it was not sufficient -- some data seems to be stored outside of that /var directory so didn't fully work: Someone who just has a clue in postgres might want to look to bind mount the location for the DB itself (/var/lib/postgresql/9.6/main/) so DB could then reside outside of docker along side with the books.  Probably should be bindmounted somewhere aside and then the startpoint.sh should do needed initial rsync and adjustments to config to use it instead of the blank installed one.
- [x] if `/srv/configs/{instructors,students}.csv` files provided, then DB is populated with those accounts and new signups are disabled

Not sure if I will accomplish all of the above TODOs but want to reach a usable for myself state first to consider it at least "done enough", the rest of non-fulfilled TODOs then could be migrated to a separate issue.

## Initial working version
Ok, initial version is pushed and here is how you could try it yourself after you get docker installed (let me know if I should just push that image, but better if you just build it yourself for now):

```shell
$> docker build --tag yarikoptic-runestone:0.1.0 .
...
$> docker run -it -p 8081:8080 -e DB_PASSWORD=123 -v $HOME/runestone/books:/srv/web2py/applications/runestone/books  yarikoptic-runestone:0.1.0
...
```
where I have one book (fopp) subfolder under  `$HOME/runestone/books`. And that is it!  you then should be having a docker container running exposing runestone on port 8081 (and internally within container it would be hardcoded 8080). So could be mapped to 80 etc.  If you add `--rm` to the run invocation - that created/configured container would be removed after a "trial run".  If you don't (like it is now), you could check that container's id using e.g. `docker ps`, and then use `docker stop` and `docker start` to stop/start it back and forth.  It shouldn't then reinitialize anything -- would just pretty much restart the services.

And that is where I would need your help -- to actually make it work

- [x] #1179 - some hardcoded http://127.0.0.1:8000 -- requires per book master_url tune up to be an empty string
- [x] Probably "not fully" logged in. When I try to run any code cell, getting "WARNING:  Your code was not saved!  Please Try again". edit: this is another manifestation of #1179 - goes to 127.0.0.1 instead of FQDN. Was indeed manifestation of #1179 
- [x] If you go to the top page for the web2py - you would get forwarded to "welcome/default/index" and see all the web2py frameworkiness.  Pending push: removed welcome and the other py2web applications, and made `runestone` the default one
- [ ] although, following README, I enabled https:// - it runs as regular http.  And not sure how "https" could just work without me specifying all the certificates setup etc.  Could README.md clarify the needed setup? (or just push needed changes to that `docker/entrypoint.sh` in this PR)

I would really appreciate you giving it a try and helping out to resolve those few issues to get it fully working ;-)

Closes #1176 