### PR TITLE
Fix: Avoid exception when displaying the gradebook.

### DIFF
--- a/modules/rs_grading.py
+++ b/modules/rs_grading.py
@@ -428,7 +428,7 @@ def _get_students(course_id, sid = None, db=None):
     return student_rows
 
 def send_lti_grade(assignment_points, score, consumer, secret, outcome_url, result_sourcedid):
-    pct = score / float(assignment_points) if assignment_points else 0.0
+    pct = score / float(assignment_points) if score and assignment_points else 0.0
     # print "pct", pct
 
     # send it back to the LMS


### PR DESCRIPTION
Sometimes, `score` is `None`, causing an exception.