### PR TITLE
Fix broken tests.

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,5 +1,6 @@
 import unittest
 import json
+import sys
 from gluon.globals import Request, Session
 from gluon.tools import Auth
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -10,6 +10,8 @@
 #
 
 import unittest
+import sys
+
 from gluon.globals import Request, Session
 from gluon.tools import Auth
 


### PR DESCRIPTION
This fixes errors caused when `sys` is used, but never imported.