### PR TITLE
Fix: Let application name determine masterapp for session storage.

### DIFF
--- a/models/db.py
+++ b/models/db.py
@@ -22,7 +22,7 @@ if not request.env.web2py_runtime_gae:
         # WEB2PY_MIGRATE is either "Yes", "No", "Fake", or missing
         db = DAL(settings.database_uri, fake_migrate_all=(os.environ.get("WEB2PY_MIGRATE", "Yes") == 'Fake'),
                  migrate=False, migrate_enabled=(os.environ.get("WEB2PY_MIGRATE", "Yes") in ['Yes', 'Fake']))
-    session.connect(request, response, masterapp='runestone', db=db, migrate='runestone_web2py_sessions.table')
+    session.connect(request, response, db, masterapp=None, migrate='runestone_web2py_sessions.table')
 
 else:
     ## connect to Google BigTable (optional 'google:datastore://namespace')


### PR DESCRIPTION
This is one more place where we can avoid hard-coding the application name, without changing the behavior of the Runestone server.