### PR TITLE
Fix: Display progress while grading without blocking.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -155,17 +155,20 @@ function autoGrade() {
     }
 
     if (assignment != null && question === null && studentID == null) {
-        let i = 0;
-        for (let s in students) {
-            params.data.sid = s;
-            params.async = false;
-            let res = jQuery.ajax(params);
-            setTimeout(function(s) {
-                $("#autogradingform").append(`${res.responseJSON.message} for ${s} </br>`)
-            }, 10, s);
-        }
-        calculateTotals();
-        $("#autogradesubmit").prop("disabled", false);
+        (async function(students, ajax_params) {
+            // Grade each student provided.
+            let student_array = Object.keys(students);
+            for (let index = 0; index < student_array.length; ++index) {
+                let student = student_array[index];
+                ajax_params.data.sid = student;
+                res = await jQuery.ajax(ajax_params);
+                $("#autogradingprogress").html(`Student ${index + 1} of ${student_array.length}: ${res.message} for ${student}`);
+            }
+            // Clear the graing progress.
+            $("#autogradingprogress").html('');
+            calculateTotals();
+            $("#autogradesubmit").prop("disabled", false);
+        })(students, params);
     } else {
         jQuery.ajax(params).always(function () {
             calculateTotals();

--- a/views/admin/grading.html
+++ b/views/admin/grading.html
@@ -68,6 +68,9 @@
     </form>
   </div>
 
+  <div id="autogradingprogress">
+  </div>
+
   <div id="assignmentTotalform" style="text-align: center; visibility: hidden; background-color: rgba(219,103,14,.71); margin: 10px; padding: 5px; border-radius: 10px;">
     <strong>Override student score for whole assignment.</strong>
     <form>
@@ -136,7 +139,7 @@
   var assignmentids = JSON.parse(document.getElementById("getassignmentids").innerHTML);
   var assignment_deadlines = JSON.parse(document.getElementById("getassignment_deadlines").innerHTML);
   var question_points = JSON.parse(document.getElementById("getquestion_points").innerHTML);
-  
+
   $('#autogradingform').submit(function(event) {
     event.preventDefault();
     $("#autogradesubmit").prop("disabled", true);


### PR DESCRIPTION
This uses JavaScript's async capabilities to avoid blocking while performing grading. Without this, my browser (Chrome) freezes while doing grading. It also provide a nice display of what's currently being graded. With 180 students in my course, this is essential.