### PR TITLE
Pivot reports

### DIFF
--- a/controllers/dashboard.py
+++ b/controllers/dashboard.py
@@ -328,7 +328,7 @@ def subchapoverview():
     data = pd.read_sql_query("""
     select sid, useinfo.timestamp, div_id, chapter, subchapter from useinfo
     join questions on div_id = name
-    where course_id = '{}'""".format(course), os.environ.get('DBURL'))
+    where course_id = '{}'""".format(course), settings.database_uri)
     data = data[~data.sid.str.contains('@')]
     if 'tablekind' not in request.vars:
         request.vars.tablekind = 'sccount'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,5 @@ pytest
 contextlib2
 # Install the development version of the Runstone Components, rather than the released version.
 https://github.com/RunestoneInteractive/RunestoneComponents/archive/master.zip
+# Beautiful soup
+beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ oauth2>=1.9
 bleach>=3.0
 pathlib2
 stripe
+pandas
 -e rsmanage/

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -15,6 +15,7 @@ from bs4 import BeautifulSoup
 
 from gluon.globals import Request, Session
 from gluon.tools import Auth
+from StringIO import StringIO
 
 # bring in the ajax controllers
 
@@ -61,6 +62,19 @@ class TestDashboardEndpoints(unittest.TestCase):
         cl = rl[10].select('td')
         self.assertEqual(cl[5].text, '4.0')
         self.assertEqual(cl[17].text, '6.0')
+        request.vars.action = 'tocsv'
+        request.vars.tablekind = 'dividmin'
+        res = subchapoverview()
+        csvf = StringIO(res)
+        rows = csvf.readlines()
+        cols = rows[18].split(',')
+        self.assertEqual(cols[0], 'Dictionaries')
+        self.assertEqual(cols[2], 'ch12_dict11')
+        self.assertEqual(cols[-1].strip(), '2017-10-26 22:25:38')
+        cols = rows[122].split(',')
+        self.assertEqual(cols[0], 'GeneralIntro')
+        self.assertEqual(cols[3], '2017-08-30 22:29:30')
+
 
 suite = unittest.TestSuite()
 suite.addTest(unittest.makeSuite(TestDashboardEndpoints))

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -11,6 +11,7 @@
 
 import unittest
 import sys
+from bs4 import BeautifulSoup
 
 from gluon.globals import Request, Session
 from gluon.tools import Auth
@@ -45,6 +46,21 @@ class TestDashboardEndpoints(unittest.TestCase):
         self.assertEqual(res['assignments']['List Practice']['class_average'], '7.82') #todo: why a string?
 
 
+
+    def test_subchapoverview(self):
+        auth.login_user(db.auth_user(11))
+        session.auth = auth
+        request.vars.tablekind = 'sccount'
+
+        res = subchapoverview()
+        self.assertIsNotNone(res)
+        soup = BeautifulSoup(res['summary'])
+        thlist = soup.select('th')
+        self.assertEqual(thlist[11].text, 'user_1671')
+        rl = soup.select('tr')
+        cl = rl[10].select('td')
+        self.assertEqual(cl[5].text, '4.0')
+        self.assertEqual(cl[17].text, '6.0')
 
 suite = unittest.TestSuite()
 suite.addTest(unittest.makeSuite(TestDashboardEndpoints))

--- a/views/dashboard/index.html
+++ b/views/dashboard/index.html
@@ -10,7 +10,7 @@
 <script src="{{=URL('static', 'dashboard-charts.js')}}"></script>
 
 <div id="dashboard">
-	<h1 style="display: block-inline">{{=course_name}}
+	<h1>{{=course_name}}
 		<span class="dash-title-description">Instructor Dashboard</span>
 		<a href="{{=URL('dashboard','subchapoverview')}}" style="font-size: small">Overview Reports</a>
 	</h1>

--- a/views/dashboard/index.html
+++ b/views/dashboard/index.html
@@ -10,7 +10,10 @@
 <script src="{{=URL('static', 'dashboard-charts.js')}}"></script>
 
 <div id="dashboard">
-	<h1>{{=course_name}} <span class="dash-title-description">Instructor Dashboard</span></h1>
+	<h1 style="display: block-inline">{{=course_name}}
+		<span class="dash-title-description">Instructor Dashboard</span>
+		<a href="{{=URL('dashboard','subchapoverview')}}" style="font-size: small">Overview Reports</a>
+	</h1>
 	<h2 style="width: 800px; display: inline;">{{=selected_chapter['chapter_name']}}</h2>
 	<div style="float: right"><b>Select Chapter</b>
 					<select onchange="window.location=[window.location.protocol, '//', window.location.host, window.location.pathname].join('') + '?chapter=' + this.value;">

--- a/views/dashboard/subchapoverview.html
+++ b/views/dashboard/subchapoverview.html
@@ -1,0 +1,22 @@
+{{extend 'admin/instructors.html'}}
+
+{{ block tabcontent }}
+<h2>{{=course_name}}</h2>
+<hr>
+
+<form action="/runestone/dashboard/subchapoverview" style="display: inline-block">
+    <select name="tablekind" id="tabselect" onchange="this.form.submit()">
+        <option value="sccount" {{if request.vars.tablekind == 'sccount':}}selected{{pass}}>Count of Subchapter Activities</option>
+        <option value="dividmin" {{if request.vars.tablekind == 'dividmin':}}selected{{pass}}>First Interaction with all Activities</option>
+        <option value="dividmax" {{if request.vars.tablekind == 'dividmax':}}selected{{pass}}>Last Interaction with all Activities</option>
+        <option value="dividnum" {{if request.vars.tablekind == 'dividnum':}}selected{{pass}}>Number of Interactions with each Activity</option>
+    </select>
+</form>
+
+<button onclick="$('#scsummary').tableToCSV()">Download Table to CSV</button>
+
+{{=XML(summary)}}
+
+<script src="/runestone/static/js/jquery.tabletoCSV.js"></script>
+
+{{ end }}

--- a/views/dashboard/subchapoverview.html
+++ b/views/dashboard/subchapoverview.html
@@ -11,12 +11,10 @@
         <option value="dividmax" {{if request.vars.tablekind == 'dividmax':}}selected{{pass}}>Last Interaction with all Activities</option>
         <option value="dividnum" {{if request.vars.tablekind == 'dividnum':}}selected{{pass}}>Number of Interactions with each Activity</option>
     </select>
+
+    <button type="submit" name="action" value="tocsv">Download CSV</button>
 </form>
 
-<button onclick="$('#scsummary').tableToCSV()">Download Table to CSV</button>
-
 {{=XML(summary)}}
-
-<script src="/runestone/static/js/jquery.tabletoCSV.js"></script>
 
 {{ end }}


### PR DESCRIPTION
This  is in response to one of the top requested features I get from instructors, more granularity than they get in the student progress page and the ability to download data in a useful form. I think this addresses that without just giving them a dump of the firehose that is useinfo.

It gives them 4 reports

1.  student by subchapter with a count of the number of distinct activities each student has done.
2. student by subchapter-div_id with a timestamp of the first time they interacted with an activity
3. student by subchapter-div_id with a timestamp of the last time they interacted with an activity
5. student by subchapter-div_id with a count of the number of times they interactive with an activity

<img width="1005" alt="Screen Shot 2019-04-09 at 10 45 05 AM" src="https://user-images.githubusercontent.com/51115/55823404-7b424880-5ab6-11e9-801a-d3273d5dc866.png">

To anticipate -- I'm thinking about how I would write a unit test for this @bjones1 .