### PR TITLE
Updates for Python 3

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,11 +1,11 @@
 Runestone ChangeLog
 ===================
 
-3.5.x August 2015
+3.5.x August 2015 - X 2019
 -----------------
 
 * Addition of Dockerfile for container deployment
-
+* Conversion to Python 3
 
 3.1.1 September 1, 2014
 -----------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ ENV RUNESTONE_PATH=${WEB2PY_APPS_PATH}/runestone
 ENV BOOKS_PATH=${RUNESTONE_PATH}/books
 ENV WEB2PY_VERSION=2.18.4
 
+# Click needs these encodings for Python 3
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 # Expose that port on the network
 EXPOSE ${WEB2PY_PORT}
@@ -45,14 +48,13 @@ RUN apt-get update && \
         gcc \
         git \
         unzip \
-        python-pip libfreetype6-dev postgresql-common postgresql postgresql-contrib \
+        python3-pip libfreetype6-dev postgresql-common postgresql postgresql-contrib \
         libpq-dev libxml2-dev libxslt1-dev \
-        python-setuptools \
-        python-numpy \
-        python-dev \
-        python-wheel rsync wget nginx && \
+        python3-setuptools \
+        python3-numpy \
+        python3-dev \
+        python3-wheel rsync wget nginx && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 
 # The rest could be done and ran under a regular (well, staff for installing under /usr/local) user
 RUN useradd -s /bin/bash -M -g staff --home-dir ${WEB2PY_PATH} runestone && \
@@ -72,13 +74,17 @@ WORKDIR ${RUNESTONE_PATH}
 # base courses as their course when using docker to host their own courses.
 RUN mkdir -p private && \
     echo "sha512:16492eda-ba33-48d4-8748-98d9bbdf8d33" > private/auth.key && \
-    pip install --system -r requirements.txt && \
-    pip install --system -r requirements-test.txt && \
+    pip3 install --system -r requirements.txt && \
+    pip3 install --system -r requirements-test.txt && \
     rm -rf ${WEB2PY_PATH}/.cache/* && \
     cp ${RUNESTONE_PATH}/scripts/run_scheduler.py ${WEB2PY_PATH}/run_scheduler.py && \
     cp ${RUNESTONE_PATH}/scripts/routes.py ${WEB2PY_PATH}/routes.py
 
 WORKDIR ${WEB2PY_PATH}
+
+# Link Python 3 to 2, since Python 3 installs as python3 / pip3
+RUN ln -s /usr/bin/python3 /usr/bin/python && \
+    ln -s /usr/bin/pip3 /usr/bin/pip
 
 # All configuration will be done within entrypoint.sh upon initial run
 # of the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-backports
+FROM library/python:3.7-stretch
 
 LABEL authors="@bnmnetp,@vsoch,@yarikoptic"
 
@@ -74,21 +74,16 @@ WORKDIR ${RUNESTONE_PATH}
 # base courses as their course when using docker to host their own courses.
 RUN mkdir -p private && \
     echo "sha512:16492eda-ba33-48d4-8748-98d9bbdf8d33" > private/auth.key && \
-    pip3 install --system -r requirements.txt && \
-    pip3 install --system -r requirements-test.txt && \
+    pip3 install -r requirements.txt && \
+    pip3 install -r requirements-test.txt && \
     rm -rf ${WEB2PY_PATH}/.cache/* && \
     cp ${RUNESTONE_PATH}/scripts/run_scheduler.py ${WEB2PY_PATH}/run_scheduler.py && \
     cp ${RUNESTONE_PATH}/scripts/routes.py ${WEB2PY_PATH}/routes.py
 
 WORKDIR ${WEB2PY_PATH}
 
-# Link Python 3 to 2, since Python 3 installs as python3 / pip3
-RUN ln -s /usr/bin/python3 /usr/bin/python && \
-    ln -s /usr/bin/pip3 /usr/bin/pip
-
 # All configuration will be done within entrypoint.sh upon initial run
 # of the container
 COPY docker/entrypoint.sh /usr/local/sbin/entrypoint.sh
 
-#RUN chown -R runestone /srv
 CMD /bin/bash /usr/local/sbin/entrypoint.sh

--- a/build/preview/conf.py
+++ b/build/preview/conf.py
@@ -229,4 +229,3 @@ html_show_sourcelink = False
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'PythonCoursewareProjectdoc'
-

--- a/controllers/coach.py
+++ b/controllers/coach.py
@@ -72,4 +72,3 @@ def lintMany():
 
 if __name__ == '__main__':
     lintMany()
-

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -110,7 +110,7 @@ fi
 # Run the beast
 info "Starting the server"
 cd "$WEB2PY_PATH"
-python web2py.py --ip=0.0.0.0 --port=8080 --password="${POSTGRES_PASSWORD}" -K runestone --nogui -X runestone  &
+python web2py.py --ip=0.0.0.0 --port=8080 --password="${POSTGRES_PASSWORD}" -K runestone --nogui -X  &
 
 ## Go through all books and build
 info "Building & Deploying books"


### PR DESCRIPTION
The work to make (at least the superficial running) work with Python 3 was fairly simple -

 1. exporting encoding environment variables supported (see locale -a for the three) so that click didn't bug out.
 2. updating the container installs to python3-X
 3. Creating a symbolic link from python3 to 2 so "python3" isn't hard coded everywhere.
 4. There was one strange error that web2py didn't like having "runestone" at the end. The -X variable is a flag for running with the scheduler, so I'm guessing that wherever the args are ultimately parsed (the gluon thing?) has a difference between Python 2/3. It seems to work okay removing it, so I'll want your feedback on this.

I suspect that the RunestoneInteractive/RunestoneComponents might need work, along with some of the books? I wasn't sure how to properly run tests, so that's something else to do (and I'm hoping this PR kicks that off). Hopefully this is a good start!

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>