### PR TITLE
config files for uwsgi + nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,8 @@ RUN apt-get update && \
         python3-setuptools \
         python3-numpy \
         python3-dev \
-        python3-wheel rsync wget nginx && \
+        python3-wheel \
+        rsync wget nginx uwsgi uwsgi-plugin-python3 && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # The rest could be done and ran under a regular (well, staff for installing under /usr/local) user
@@ -77,7 +78,6 @@ RUN mkdir -p private && \
     echo "sha512:16492eda-ba33-48d4-8748-98d9bbdf8d33" > private/auth.key && \
     pip3 install -r requirements.txt && \
     pip3 install -r requirements-test.txt && \
-    pip3 install uwsgi && \
     rm -rf ${WEB2PY_PATH}/.cache/* && \
     cp ${RUNESTONE_PATH}/scripts/run_scheduler.py ${WEB2PY_PATH}/run_scheduler.py && \
     cp ${RUNESTONE_PATH}/scripts/routes.py ${WEB2PY_PATH}/routes.py
@@ -94,5 +94,7 @@ COPY docker/nginx/sites-available/runestone /etc/nginx/sites-enabled/runestone
 COPY docker/uwsgi/sites/runestone.ini /etc/uwsgi/sites/runestone.ini
 COPY docker/systemd/system/uwsgi.service /etc/systemd/system/uwsgi.service
 COPY docker/wsgihandler.py /srv/web2py/wsgihandler.py
+RUN ln -s /etc/systemd/system/uwsgi.service /etc/systemd/system/multi-user.target.wants/uwsgi.service
+RUN rm /etc/nginx/sites-enabled/default
 
 CMD /bin/bash /usr/local/sbin/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && \
         gcc \
         git \
         unzip \
+        emacs-nox \
         python3-pip libfreetype6-dev postgresql-common postgresql postgresql-contrib \
         libpq-dev libxml2-dev libxslt1-dev \
         python3-setuptools \
@@ -76,6 +77,7 @@ RUN mkdir -p private && \
     echo "sha512:16492eda-ba33-48d4-8748-98d9bbdf8d33" > private/auth.key && \
     pip3 install -r requirements.txt && \
     pip3 install -r requirements-test.txt && \
+    pip3 install uwsgi && \
     rm -rf ${WEB2PY_PATH}/.cache/* && \
     cp ${RUNESTONE_PATH}/scripts/run_scheduler.py ${WEB2PY_PATH}/run_scheduler.py && \
     cp ${RUNESTONE_PATH}/scripts/routes.py ${WEB2PY_PATH}/routes.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,13 +49,9 @@ RUN apt-get update && \
         git \
         unzip \
         emacs-nox \
-        python3-pip libfreetype6-dev postgresql-common postgresql postgresql-contrib \
+        libfreetype6-dev postgresql-common postgresql postgresql-contrib \
         libpq-dev libxml2-dev libxslt1-dev \
-        python3-setuptools \
-        python3-numpy \
-        python3-dev \
-        python3-wheel \
-        rsync wget nginx uwsgi uwsgi-plugin-python3 && \
+        rsync wget nginx && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # The rest could be done and ran under a regular (well, staff for installing under /usr/local) user
@@ -78,6 +74,7 @@ RUN mkdir -p private && \
     echo "sha512:16492eda-ba33-48d4-8748-98d9bbdf8d33" > private/auth.key && \
     pip3 install -r requirements.txt && \
     pip3 install -r requirements-test.txt && \
+    pip3 install uwsgi && \
     rm -rf ${WEB2PY_PATH}/.cache/* && \
     cp ${RUNESTONE_PATH}/scripts/run_scheduler.py ${WEB2PY_PATH}/run_scheduler.py && \
     cp ${RUNESTONE_PATH}/scripts/routes.py ${WEB2PY_PATH}/routes.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,4 +88,11 @@ WORKDIR ${WEB2PY_PATH}
 # of the container
 COPY docker/entrypoint.sh /usr/local/sbin/entrypoint.sh
 
+# Copy configuration files to get nginx and uwsgi up and running
+RUN mkdir -p /etc/nginx/sites-enabled
+COPY docker/nginx/sites-available/runestone /etc/nginx/sites-enabled/runestone
+COPY docker/uwsgi/sites/runestone.ini /etc/uwsgi/sites/runestone.ini
+COPY docker/systemd/system/uwsgi.service /etc/systemd/system/uwsgi.service
+COPY docker/wsgihandler.py /srv/web2py/wsgihandler.py
+
 CMD /bin/bash /usr/local/sbin/entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     links:
       - db
     ports:
-      - "8080:8080"
+      - "80:80"
     environment:
       POSTGRES_PASSWORD: 'runestone'
       POSTGRES_USER: 'runestone'

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,6 +18,8 @@ cd books
 git clone https://github.com/RunestoneInteractive/thinkcspy.git
 ```
 
+After cloning the book edit the pavement.py file.  It is **critical** that the `master_url` variable in that file is set correctly.  If you are running docker and doing your development on the same machine then `http://localhost` will work. If you are running docker on a remote host then make sure to set it to the name of the remote host. `master_url` is the URL that the API calls in the browser will use to connect to the server running in the docker container.
+
 ### 2. Add Users
 
 If you have an instructors.csv or students.csv that you want to add to the database,

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -117,7 +117,10 @@ fi
 # Run the beast
 info "Starting the server"
 cd "$WEB2PY_PATH"
-python web2py.py --ip=0.0.0.0 --port=8080 --password="${POSTGRES_PASSWORD}" -K runestone --nogui -X  &
+#python web2py.py --ip=0.0.0.0 --port=8080 --password="${POSTGRES_PASSWORD}" -K runestone --nogui -X  &
+
+service uwsgi start
+service nginx start
 
 ## Go through all books and build
 info "Building & Deploying books"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -82,6 +82,10 @@ case $dbstate in
 
 esac
 
+chown -R www-data /srv/web2py
+mkdir -p /run/uwsgi
+chown -R www-data /run/uwsgi
+
 RETRIES=5
 
 until psql $DBURL -c "select 1" > /dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
@@ -117,10 +121,15 @@ fi
 # Run the beast
 info "Starting the server"
 cd "$WEB2PY_PATH"
-#python web2py.py --ip=0.0.0.0 --port=8080 --password="${POSTGRES_PASSWORD}" -K runestone --nogui -X  &
 
-service uwsgi start
+# To just run the development server Do this:
+# python web2py.py --ip=0.0.0.0 --port=8080 --password="${POSTGRES_PASSWORD}" -K runestone --nogui -X  &
+
+# To start in a mode more consistent with deployment Do this:
 service nginx start
+
+/usr/local/bin/uwsgi --ini /etc/uwsgi/sites/runestone.ini &
+
 
 ## Go through all books and build
 info "Building & Deploying books"

--- a/docker/nginx/sites-available/runestone
+++ b/docker/nginx/sites-available/runestone
@@ -1,0 +1,17 @@
+server {
+    listen  80 default_server;
+    include /etc/nginx/default.d/*.conf;
+
+    location ~* /(\w+)/static/ {
+            root /srv/web2py/applications/;
+    }
+
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:/run/uwsgi/web2py.sock;
+        uwsgi_param	DBURL	postgresql://runestone:passworda@localhost/runestone;
+        uwsgi_param     WEB2PY_CONFIG production;
+    }
+}
+
+

--- a/docker/systemd/system/uwsgi.service
+++ b/docker/systemd/system/uwsgi.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=uWSGI Emperor Service
+
+[Service]
+ExecStartPre=/bin/bash -c 'mkdir -p /run/uwsgi; chown www-data:www-data /run/uwsgi'
+ExecStart=/usr/local/bin/uwsgi --emperor /etc/uwsgi/sites
+Restart=always
+KillSignal=SIGQUIT
+Type=notify
+NotifyAccess=all
+
+[Install]
+WantedBy=multi-user.target

--- a/docker/uwsgi/sites/runestone.ini
+++ b/docker/uwsgi/sites/runestone.ini
@@ -5,7 +5,7 @@ uid = www-data
 gid = www-data
 
 master = true
-processes = 18
+processes = 9
 threads = 3
 master-fifo = /tmp/bnmuwsgi
 master-log = true

--- a/docker/uwsgi/sites/runestone.ini
+++ b/docker/uwsgi/sites/runestone.ini
@@ -1,0 +1,27 @@
+[uwsgi]
+chdir = /srv/web2py
+module = wsgihandler:application
+uid = bmiller
+gid = www-data
+
+master = true
+processes = 18
+threads = 3
+master-fifo = /tmp/bnmuwsgi
+master-log = true
+logto = /srv/web2py/logs/uwsgi.log
+log-maxsize = 100000000
+
+socket = /run/uwsgi/web2py.sock
+chown-socket = www-data:www-data
+chmod-socket = 660
+vacuum = true
+
+mule = /srv/web2py/run_scheduler.py
+memory-report = true
+reload-on-rss = 200
+max-requests = 500
+harakiri = 25
+listen = 124
+static-map = /runestone/static=/srv/web2py/applications/runestone/static
+

--- a/docker/uwsgi/sites/runestone.ini
+++ b/docker/uwsgi/sites/runestone.ini
@@ -1,7 +1,7 @@
 [uwsgi]
 chdir = /srv/web2py
 module = wsgihandler:application
-uid = bmiller
+uid = www-data
 gid = www-data
 
 master = true

--- a/docker/wsgihandler.py
+++ b/docker/wsgihandler.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+This file is part of the web2py Web Framework
+Copyrighted by Massimo Di Pierro <mdipierro@cs.depaul.edu>
+License: LGPLv3 (http://www.gnu.org/licenses/lgpl.html)
+
+
+This is a WSGI handler
+"""
+
+import sys
+import os
+
+# change these parameters as required
+LOGGING = False
+SOFTCRON = False
+
+
+path = os.path.dirname(os.path.abspath(__file__))
+os.chdir(path)
+
+if not os.path.isdir('applications'):
+    raise RuntimeError('Running from the wrong folder')
+
+sys.path = [path] + [p for p in sys.path if not p == path]
+
+import gluon.main
+
+if LOGGING:
+    application = gluon.main.appfactory(wsgiapp=gluon.main.wsgibase,
+                                        logfilename='httpserver.log',
+                                        profiler_dir=None)
+else:
+    application = gluon.main.wsgibase
+
+if SOFTCRON:
+    from gluon.settings import global_settings
+    global_settings.web2py_crontype = 'soft'


### PR DESCRIPTION
These config files are based on the config files from my setup on Digital Ocean running an Ubuntu 16.04 droplet.  This does seem to be compatible with the debian-stretch image that we use as our base.

- [x] copy docker/nginx/sites-available/runestone to /etc/nginx/sites-enabled
- [x] copy docker/uwsgi/sites/runestone.ini to /etc/uwsgi/sites/runestone.ini
- [x] copy docker/systemd/system/uwsgi.service to /etc/systemd/system/uwsgi.service
- [x] copy docker/wsgihandler.py to /srv/web2py/wsgihandler.py
- [x] enable both uwsgi and nginx to start up 

- [x] Expose the nginx service on some port probably not 80 as it is here?

On digital ocean things are owned and run as the bmiller user.  I've tried to update here to have them owned and run as www-data.  

