### PR TITLE
Misc fixes

### DIFF
--- a/controllers/ajax.py
+++ b/controllers/ajax.py
@@ -32,7 +32,7 @@ EVENT_TABLE = {'mChoice':'mchoice_answers',
 
 
 def compareAndUpdateCookieData(sid):
-    if 'ipuser' in request.cookies and request.cookies['ipuser'].value != sid:
+    if 'ipuser' in request.cookies and request.cookies['ipuser'].value != sid and request.cookies['ipuser'].value.endswith("@"+request.client):
         db.useinfo.update_or_insert(db.useinfo.sid == request.cookies['ipuser'].value, sid=sid)
 
 def hsblog():

--- a/controllers/designer.py
+++ b/controllers/designer.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # this file is released under public domain and you can use without limitations
 from os import path
-import uuid
 import shutil
 import random
 


### PR DESCRIPTION
A couple of minor tweaks. The subtle one I found in testing:

1. A user logs in, does stuff, then logs out.
2. Using the same PC and web browser, another user then hits the `hsblog` endpoint without logging in. Then, the `compareAndUpdateCookieData` function sees the two users as identical. It therefore updates the `useinfo` table with the second user's data, which actually overwrites values the first user submitted. I added an extra check to prevent overwriting a logged-in user with a logged-out user's data.