### PR TITLE
Test improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ script:
 - cd books
 - git clone https://github.com/RunestoneInteractive/thinkcspy.git
 - cd ..
+# This directory doesn't exist; its lack causes test failures when web2py tries to append to
+# `databases/sql.log`.
+- mkdir databases
 - cd tests
 # Now actually run the tests, rebuilding the database first.
 - python run_tests.py --rebuildgrades

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,7 @@ script:
 - git clone https://github.com/RunestoneInteractive/thinkcspy.git
 - cd ..
 - cd tests
-# Now actually run the tests.
-- python run_tests.py
-# Rebuild the grades just to make sure this works.
+# Now actually run the tests, rebuilding the database first.
 - python run_tests.py --rebuildgrades
 notifications:
   slack:

--- a/models/db.py
+++ b/models/db.py
@@ -14,15 +14,19 @@ from gluon import current
 ## be redirected to HTTPS, uncomment the line below:
 # request.requires_htps()
 
+table_migrate_prefix = 'runestone_'
+table_migrate_prefix_test = ''
 if not request.env.web2py_runtime_gae:
     ## if NOT running on Google App Engine use SQLite or other DB
     if os.environ.get("WEB2PY_CONFIG","") == 'test':
-        db = DAL(settings.database_uri,migrate=False,migrate_enabled=False)
+        db = DAL(settings.database_uri, migrate=True)
+        table_migrate_prefix = 'test_runestone_'
+        table_migrate_prefix_test = table_migrate_prefix
     else:
         # WEB2PY_MIGRATE is either "Yes", "No", "Fake", or missing
         db = DAL(settings.database_uri, fake_migrate_all=(os.environ.get("WEB2PY_MIGRATE", "Yes") == 'Fake'),
                  migrate=False, migrate_enabled=(os.environ.get("WEB2PY_MIGRATE", "Yes") in ['Yes', 'Fake']))
-    session.connect(request, response, db, masterapp=None, migrate='runestone_web2py_sessions.table')
+    session.connect(request, response, db, masterapp=None, migrate=table_migrate_prefix + 'web2py_sessions.table')
 
 else:
     ## connect to Google BigTable (optional 'google:datastore://namespace')

--- a/models/db_ebook.py
+++ b/models/db_ebook.py
@@ -43,7 +43,7 @@ db.define_table('acerror_log',
                 Field('course_id','string'),
                 Field('code','text'),
                 Field('emessage','text'),
-                migrate='runestone_acerror_log.table'
+                migrate=table_migrate_prefix + 'acerror_log.table'
                 )
 
 ##table to store the last position of the user. 1 row per user, per course
@@ -56,7 +56,7 @@ db.define_table('user_state',
   Field('last_page_subchapter','string'),
   Field('last_page_scroll_location','string'),
   Field('last_page_accessed_on','datetime'),
-  migrate='runestone_user_state.table'
+  migrate=table_migrate_prefix + 'user_state.table'
 )
 
 # Table to match instructor(s) to their course(s)
@@ -75,7 +75,7 @@ db.define_table('coach_hints',
     Field('obj','string'),
     Field('msg','string'),
     Field('source',db.acerror_log),
-    migrate='runestone_coach_hints.table'
+    migrate=table_migrate_prefix + 'coach_hints.table'
     )
 
 db.define_table('timed_exam',
@@ -88,7 +88,7 @@ db.define_table('timed_exam',
     Field('skipped','integer'),
     Field('time_taken','integer'),
     Field('reset','boolean'),
-    migrate='runestone_timed_exam.table'
+    migrate=table_migrate_prefix + 'timed_exam.table'
     )
 
 db.define_table('mchoice_answers',
@@ -163,7 +163,7 @@ db.define_table('payments',
     Field('user_courses_id', db.user_courses, required=True),
     # A `Stripe charge ID <https://stripe.com/docs/api/charges/object#charge_object-id>`_. Per the `Stripe docs <https://stripe.com/docs/upgrades>`_, this is always 255 characters or less.
     Field('charge_id', 'string', length=255, required=True),
-    migrate='runestone_payments.table'
+    migrate=table_migrate_prefix + 'payments.table'
     )
 
 db.define_table('lp_answers',
@@ -173,5 +173,5 @@ db.define_table('lp_answers',
     Field('course_name','string'),
     Field('answer','text'),
     Field('correct','double'),
-    migrate='runestone_lp_answers.table'
+    migrate=table_migrate_prefix + 'lp_answers.table'
     )

--- a/models/db_ebook_chapters.py
+++ b/models/db_ebook_chapters.py
@@ -44,7 +44,7 @@ db.define_table('sub_chapter_taught',
   Field('chapter_label', 'string'),
   Field('sub_chapter_label', 'string'),
   Field('teaching_date', 'date', default=datetime.datetime.utcnow()),
-  migrate='runestone_sub_chapter_taught.table'
+  migrate=table_migrate_prefix + 'sub_chapter_taught.table'
 )
 
 #

--- a/models/db_ebook_groups.py
+++ b/models/db_ebook_groups.py
@@ -3,13 +3,13 @@ db.define_table('cohort_plan',
   Field('chapter_id','reference chapters'),
   Field('start_date','date'),
   Field('end_date','date'),
-  Field('note','string'),                
+  Field('note','string'),
   Field('actual_end_date','date'), #actual date when everyone completed the chapter
   Field('status','string'), #notStarted / new / modified / active / completed
   Field('created_on','datetime'),
   Field('created_by','reference auth_user'),
   Field('is_active','integer', default=1), #0 - deleted / inactive. 1 - active
-  migrate='runestone_cohort_plan.table'
+  migrate=table_migrate_prefix + 'cohort_plan.table'
 )
 
 db.define_table('cohort_plan_revisions',
@@ -17,23 +17,23 @@ db.define_table('cohort_plan_revisions',
   Field('revision_no','integer'), #Revision no of the modified plan. Calculated by max(revision_no) + 1 where cohort_id and chapter_id are matched.
   Field('cohort_id','reference cohort_master'),
   Field('chapter_id','reference chapters'),
-  Field('start_date','datetime'),                
+  Field('start_date','datetime'),
   Field('end_date','datetime'),
-  Field('note','string'),                     
-  Field('actual_end_date','datetime'), 
+  Field('note','string'),
+  Field('actual_end_date','datetime'),
   Field('status','string'),
   Field('created_on','datetime', default=request.now),
   Field('created_by','reference auth_user'),
   Field('is_active','integer', default=1),
-  migrate='runestone_cohort_plan_revisions.table'
+  migrate=table_migrate_prefix + 'cohort_plan_revisions.table'
 )
 
 db.define_table('cohort_plan_responses',
   Field('plan_id','integer'), #combination of plan and revision define which iteration was this response for
-  Field('response','integer'), #-1 - awaitnig response. 0 - rejected. 1 - accepted           
-  Field('response_by','reference auth_user'),           
+  Field('response','integer'), #-1 - awaitnig response. 0 - rejected. 1 - accepted
+  Field('response_by','reference auth_user'),
   Field('response_on','datetime', default=request.now),
-  migrate='runestone_cohort_plan_responses.table'
+  migrate=table_migrate_prefix + 'cohort_plan_responses.table'
 )
 
 db.define_table('user_comments',
@@ -43,5 +43,5 @@ db.define_table('user_comments',
   Field('comment_by','reference auth_user'),
   Field('comment_parent','reference user_comments'), #a comment as a reply to an existing comment
   Field('comment_on','datetime', default=request.now),
-  migrate='runestone_user_comments.table'
+  migrate=table_migrate_prefix + 'user_comments.table'
 )

--- a/models/db_sections.py
+++ b/models/db_sections.py
@@ -33,7 +33,7 @@ db.sections.virtualfields.append(ExtendedSection())
 db.define_table('section_users',
   Field('auth_user',db.auth_user, required=True),
   Field('section',db.sections, label="Section ID", required=True),
-  migrate= 'runestone_section_users.table',
+  migrate=table_migrate_prefix + 'section_users.table',
   )
 
 section_users = db((db.sections.id==db.section_users.section) & (db.auth_user.id==db.section_users.auth_user))
@@ -42,7 +42,7 @@ db.define_table('pipactex_deadline',
   Field('acid_prefix', 'string'),  # acid = actice code id
   Field('deadline', 'datetime'),
   Field('section', db.sections, label="Section ID"),
-  migrate='runestone_pipactex_deadline.table')
+  migrate=table_migrate_prefix + 'pipactex_deadline.table')
 
 db.pipactex_deadline.section.requires = IS_IN_DB(db, 'sections.id', '%(name)s',
                                  zero=T('choose one'))

--- a/models/grouped_assignments.py
+++ b/models/grouped_assignments.py
@@ -626,7 +626,7 @@ db.assignments.release_grades = Field.Method(lambda row, released=True: assignme
 db.define_table('problems',
     Field('assignment', db.assignments),
     Field('acid', 'string'),
-    migrate='runestones_problems.table',
+    migrate=table_migrate_prefix_test + 'runestones_problems.table',
     )
 
 db.define_table('grades',
@@ -657,7 +657,7 @@ db.define_table('deadlines',
     Field('assignment', db.assignments, requires=IS_IN_DB(db, 'assignments.id', db.assignments._format)),
     Field('section', db.sections, requires=IS_EMPTY_OR(IS_IN_DB(db, 'sections.id', '%(name)s'))),
     Field('deadline', 'datetime'),
-    migrate='runestone_deadlines.table',
+    migrate=table_migrate_prefix + 'deadlines.table',
     )
 
 db.define_table('question_grades',

--- a/models/lti.py
+++ b/models/lti.py
@@ -1,8 +1,8 @@
-db.define_table('lti_keys', 
-                Field('consumer'), 
-                Field('secret'), 
+db.define_table('lti_keys',
+                Field('consumer'),
+                Field('secret'),
                 Field('application'),
-                migrate = 'runestone_lti_keys.table'
+                migrate=table_migrate_prefix + 'lti_keys.table'
                 )
 
 

--- a/models/practice.py
+++ b/models/practice.py
@@ -16,7 +16,7 @@ db.define_table('course_practice',
                 #   assignment deadline passes.
                 # A value of 2 indicates manually by the instructor, as it is implemented currently.
                 Field('flashcard_creation_method', type='integer', default=0),
-                migrate='course_practice.table')
+                migrate=table_migrate_prefix + 'course_practice.table')
 
 
 db.define_table('user_topic_practice',
@@ -33,7 +33,7 @@ db.define_table('user_topic_practice',
                 Field('next_eligible_date', type='date'),
                 Field('creation_time', type='datetime'),
                 Field('timezoneoffset', type='integer', default=0),
-                migrate='runestone_spacing.table')
+                migrate=table_migrate_prefix + 'spacing.table')
 
 
 db.define_table('user_topic_practice_log',
@@ -51,14 +51,14 @@ db.define_table('user_topic_practice_log',
                 Field('end_practice', type='datetime'),
                 Field('timezoneoffset', type='integer', default=0),
                 Field('next_eligible_date', type='date'),
-                migrate='runestone_spacing_log.table')
+                migrate=table_migrate_prefix + 'spacing_log.table')
 
 
 db.define_table('user_topic_practice_Completion',
                 Field('user_id', db.auth_user),
                 Field('course_name', 'string'),
                 Field('practice_completion_date', type='date'),
-                migrate='user_topic_practice_Completion.table')
+                migrate=table_migrate_prefix + 'user_topic_practice_Completion.table')
 
 
 db.define_table('user_topic_practice_survey',
@@ -69,7 +69,7 @@ db.define_table('user_topic_practice_survey',
                 Field('response_time', type='datetime',
                       default=request.now, update=request.now, writable=False),
                 Field('timezoneoffset', type='integer', default=0),
-                migrate='user_topic_practice_survey.table')
+                migrate=table_migrate_prefix + 'user_topic_practice_survey.table')
 
 
 db.define_table('user_topic_practice_feedback',
@@ -80,4 +80,4 @@ db.define_table('user_topic_practice_feedback',
                 Field('response_time', type='datetime',
                       default=request.now, update=request.now, writable=False),
                 Field('timezoneoffset', type='integer', default=0),
-                migrate='user_topic_practice_feedback.table')
+                migrate=table_migrate_prefix + 'user_topic_practice_feedback.table')

--- a/models/questions.py
+++ b/models/questions.py
@@ -19,12 +19,12 @@ db.define_table('questions',
 
 db.define_table('tags',
                 Field('tag_name', type='string', unique=True),
-                migrate='runestone_tags.table')
+                migrate=table_migrate_prefix + 'tags.table')
 
 db.define_table('question_tags',
                 Field('question_id', db.questions),
                 Field('tag_id', db.tags),
-                migrate='runestone_question_tags.table')
+                migrate=table_migrate_prefix + 'question_tags.table')
 
 ## assignment <--> questions is a many-to-many relation. This table associates them
 ## points and how it's autograded are properties of a particular use of a question in an assignment,

--- a/models/scheduler.py
+++ b/models/scheduler.py
@@ -4,5 +4,5 @@ from gluon import current
 from feedback import _scheduled_builder
 
 if settings.academy_mode:
-    scheduler = Scheduler(db, migrate='runestone_', heartbeat=1)
+    scheduler = Scheduler(db, migrate=table_migrate_prefix, heartbeat=1)
     current.scheduler = scheduler

--- a/models/user_biography.py
+++ b/models/user_biography.py
@@ -7,4 +7,4 @@ db.define_table('user_biography',
   Field('laptop_type', requires=IS_IN_SET(['Windows', 'Mac', 'Chromebook', 'Unix/Linux', 'Other', 'None'])),
   Field('image', 'upload'),
   Field('confidence', 'text'),
-  migrate='runestone_user_biography.table')
+  migrate=table_migrate_prefix + 'user_biography.table')

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -71,9 +71,9 @@ if __name__ == '__main__':
         print('Skipping DB initialization.')
     else:
         # make sure runestone_test is nice and clean.
-        xqt('dropdb --echo --if-exists --host={} --user={} "{}"'.format(pgnetloc, pguser, dbname),
-            'createdb --echo --host={} --user={} "{}"'.format(pgnetloc, pguser, dbname),
-            'psql  --host={} --user={} "{}" < runestone_test.sql'.format(pgnetloc, pguser, dbname))
+        xqt('dropdb --echo --if-exists --host={} --username={} "{}"'.format(pgnetloc, pguser, dbname),
+            'createdb --echo --host={} --username={} "{}"'.format(pgnetloc, pguser, dbname),
+            'psql  --host={} --username={} "{}" < runestone_test.sql'.format(pgnetloc, pguser, dbname))
         # Let web2py recreate certain tables not in the test database.
         for path in glob.glob('../databases/test_runestone_*.table'):
             os.remove(path)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -29,11 +29,13 @@ COVER_DIRS = 'applications/runestone/modules,applications/runestone/controllers,
 
 # Assume we are running with working directory in tests
 
+
 # Functions
 # =========
 # Let web2py recreate certain tables not in the test database by removing their
 # migration metadata.
 def remove_web2py_tables():
+    print('Removing web2py test database migration information (.table files).')
     for path in glob.glob('../databases/test_runestone_*.table'):
         os.remove(path)
 
@@ -136,6 +138,7 @@ if __name__ == '__main__':
     with pushd('../../..'):
         if extra_args:
             print('Passing the additional arguments {} to pytest.'.format(' '.join(extra_args)))
+        xqt('ls -la applications/runestone/databases')
         # Now run tests.
         xqt('{} -m coverage erase'.format(sys.executable),
             '{} -m pytest -v applications/runestone/tests/test_server.py {}'.format(sys.executable, ' '.join(extra_args)),

--- a/tests/runestone_clean.sql
+++ b/tests/runestone_clean.sql
@@ -1,0 +1,26 @@
+--- ************************************************
+--- |docname|: Remove data that web2py can re-create
+--- ************************************************
+-- Any table in ``models/`` whose ``migrate`` parameter includes ``table_migrate_prefix`` will be re-created by web2py.
+
+drop table if exists
+    acerror_log,
+    coach_hints,
+    cohort_plan_responses, cohort_plan_revisions, cohort_plan,
+    course_practice,
+    deadlines,
+    lp_answers,
+    lti_keys,
+    payments,
+    pipactex_deadline,
+    problems,
+    question_tags,
+    user_topic_practice_log, user_topic_practice,
+    section_users,
+    scheduler_run, scheduler_task, scheduler_task_deps, scheduler_worker,
+    tags,
+    sub_chapter_taught,
+    timed_exam,
+    user_biography, user_comments, user_state,
+    "user_topic_practice_Completion", user_topic_practice_feedback, user_topic_practice_survey,
+    web2py_session_runestone;


### PR DESCRIPTION
Let web2py define as many tables as possible, and do a better job of recovering from a broken database.

For example, this PR doesn't touch `runestone_test.sql` and tests fail with a plain `python run_tests.py`. However, using `python run_tests.py --rebuildgrades` fixes the database and makes the test succeed.