### PR TITLE
Dash move

### DIFF
--- a/controllers/assignments.py
+++ b/controllers/assignments.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 # -------------------
 from psycopg2 import IntegrityError
 from rs_grading import do_autograde, do_calculate_totals, do_check_answer, send_lti_grade
+from db_dashboard import DashboardDataAnalyzer
 import six
 import bleach
 

--- a/controllers/dashboard.py
+++ b/controllers/dashboard.py
@@ -5,6 +5,7 @@ from operator import itemgetter
 from collections import OrderedDict
 import six
 import pandas as pd
+from db_dashboard import DashboardDataAnalyzer
 
 
 logger = logging.getLogger(settings.logger)

--- a/models/db.py
+++ b/models/db.py
@@ -63,6 +63,7 @@ crud, service, plugins = Crud(db), Service(), PluginManager()
 current.db = db
 current.settings = settings
 current.auth = auth
+current.redirect = redirect
 
 if settings.enable_captchas:
     ## Enable captcha's :-(

--- a/models/db.py
+++ b/models/db.py
@@ -63,7 +63,6 @@ crud, service, plugins = Crud(db), Service(), PluginManager()
 current.db = db
 current.settings = settings
 current.auth = auth
-current.redirect = redirect
 
 if settings.enable_captchas:
     ## Enable captcha's :-(

--- a/modules/db_dashboard.py
+++ b/modules/db_dashboard.py
@@ -188,7 +188,7 @@ class UserActivity(object):
         # returns page views for the last 7 days
         recentViewCount = 0
         current = len(self.rows) - 1
-        while current >= 0 and self.rows[current]['timestamp'] >= datetime.datetime.utcnow() - timedelta(days=7):
+        while current >= 0 and self.rows[current]['timestamp'] >= datetime.utcnow() - timedelta(days=7):
             recentViewCount += 1
             current = current - 1
         return recentViewCount
@@ -386,7 +386,7 @@ class DashboardDataAnalyzer(object):
         if not self.user:
             rslogger.debug("ERROR - NO USER username={} course_id={}".format(username, self.course_id))
             current.session.flash = 'Please make sure you are in the correct course'
-            current.redirect('/runestone/default/courses')
+            current.redirect(URL('default', 'courses'))
             # TODO: calling redirect here is kind of a hacky way to handle this.
 
         self.logs = current.db((current.db.useinfo.course_id==self.course.course_name) &
@@ -455,7 +455,7 @@ class DashboardDataAnalyzer(object):
                                                "due_date":assign["duedate"].date().strftime("%m-%d-%Y")}
 
 # This whole object is a workaround because these strings
-# are not generated and stored in the current.db. This needs automating
+# are not generated and stored in the db. This needs automating
 # to support all books.
 class IdConverter(object):
     problem_id_map = {
@@ -479,4 +479,4 @@ class IdConverter(object):
 
     @staticmethod
     def problem_id_to_text(problem_id):
-        return IdConverter.problem_id_map.get(problem_id, problem_id)
+        return IdConverter.problem_id_map.get(problem_id, "DEFUALT NAME USED WHERE??")

--- a/modules/db_dashboard.py
+++ b/modules/db_dashboard.py
@@ -344,7 +344,7 @@ class DashboardDataAnalyzer(object):
     def load_chapter_metrics(self, chapter):
         if not chapter:
             rslogger.error("chapter not set, abort!")
-            session.flash = "Error No Course Data in DB"
+            current.session.flash = "Error No Course Data in DB"
             return
 
         self.db_chapter = chapter
@@ -385,8 +385,9 @@ class DashboardDataAnalyzer(object):
                        (current.db.auth_user.course_id == self.course_id)).select(current.db.auth_user.id, current.db.auth_user.first_name, current.db.auth_user.last_name, current.db.auth_user.email, current.db.auth_user.username).first()
         if not self.user:
             rslogger.debug("ERROR - NO USER username={} course_id={}".format(username, self.course_id))
-            session.flash = 'Please make sure you are in the correct course'
-            redirect('/runestone/default/courses')
+            current.session.flash = 'Please make sure you are in the correct course'
+            current.redirect('/runestone/default/courses')
+            # TODO: calling redirect here is kind of a hacky way to handle this.
 
         self.logs = current.db((current.db.useinfo.course_id==self.course.course_name) &
                        (current.db.useinfo.sid == username) &

--- a/modules/db_dashboard.py
+++ b/modules/db_dashboard.py
@@ -457,6 +457,11 @@ class DashboardDataAnalyzer(object):
 # This whole object is a workaround because these strings
 # are not generated and stored in the db. This needs automating
 # to support all books.
+# TODO:  more user friendly naming for problems.
+# The idea here is to provide a more user friendly name for each question beyond its divid This
+# name appears on the donut charts and in the details....
+# We are most of the way there in the questions table.  But we really don't have a more friendly
+# way to identify it.  We could use its chapter-subchapter-position...
 class IdConverter(object):
     problem_id_map = {
         "pre_1":"Pretest-1: What will be the values in x, y, and z after the following lines of code execute?",
@@ -479,4 +484,4 @@ class IdConverter(object):
 
     @staticmethod
     def problem_id_to_text(problem_id):
-        return IdConverter.problem_id_map.get(problem_id, "DEFUALT NAME USED WHERE??")
+        return IdConverter.problem_id_map.get(problem_id, problem_id)

--- a/modules/db_dashboard.py
+++ b/modules/db_dashboard.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 import logging
 from datetime import datetime, timedelta
 import six
-from gluon import current
+from gluon import current, URL, redirect
 
 rslogger = logging.getLogger(current.settings.logger)
 rslogger.setLevel(current.settings.log_level)
@@ -386,7 +386,7 @@ class DashboardDataAnalyzer(object):
         if not self.user:
             rslogger.debug("ERROR - NO USER username={} course_id={}".format(username, self.course_id))
             current.session.flash = 'Please make sure you are in the correct course'
-            current.redirect(URL('default', 'courses'))
+            redirect(URL('default', 'courses'))
             # TODO: calling redirect here is kind of a hacky way to handle this.
 
         self.logs = current.db((current.db.useinfo.course_id==self.course.course_name) &

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -113,12 +113,14 @@ if __name__ == '__main__':
 
     with pushd('../../..'):
         if extra_args:
+            print(extra_args)
             print('Passing the additional arguments {} to pytest.'.format(' '.join(extra_args)))
         # Now run tests.
         xqt('{} -m coverage erase'.format(sys.executable),
-            '{} -m pytest -v applications/runestone/tests/test_dashboard.py {}'.format(sys.executable, ' '.join(extra_args)),
-            '{} -m pytest -v applications/runestone/tests/test_server.py {}'.format(sys.executable, ' '.join(extra_args)),
-            *['{} -m coverage run --append --source={} web2py.py -S runestone -M -R applications/runestone/tests/{}'.format(sys.executable, COVER_DIRS, x)
-              for x in ['test_ajax.py', 'test_admin.py', 'test_assignments.py']]
+            '{} -m pytest -v applications/runestone/tests/test_dashboard.py applications/runestone/tests/test_server.py {}'.format(sys.executable, ' '.join(extra_args)),
         )
+        if '-k' not in extra_args:
+            xqt(*['{} -m coverage run --append --source={} web2py.py -S runestone -M -R applications/runestone/tests/{}'.format(sys.executable, COVER_DIRS, x)
+                for x in ['test_ajax.py', 'test_admin.py', 'test_assignments.py']]
+            )
         xqt('{} -m coverage report'.format(sys.executable))

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -116,8 +116,9 @@ if __name__ == '__main__':
             print('Passing the additional arguments {} to pytest.'.format(' '.join(extra_args)))
         # Now run tests.
         xqt('{} -m coverage erase'.format(sys.executable),
+            '{} -m pytest -v applications/runestone/tests/test_dashboard.py {}'.format(sys.executable, ' '.join(extra_args)),
             '{} -m pytest -v applications/runestone/tests/test_server.py {}'.format(sys.executable, ' '.join(extra_args)),
             *['{} -m coverage run --append --source={} web2py.py -S runestone -M -R applications/runestone/tests/{}'.format(sys.executable, COVER_DIRS, x)
-              for x in ['test_ajax.py', 'test_admin.py', 'test_dashboard.py', 'test_assignments.py']]
+              for x in ['test_ajax.py', 'test_admin.py', 'test_assignments.py']]
         )
         xqt('{} -m coverage report'.format(sys.executable))

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -75,6 +75,9 @@ if __name__ == '__main__':
         help='Reset the unit test based on current grading code.')
     parser.add_argument('--skipdbinit', action='store_true',
         help='Skip initialization of the test database.')
+    parser.add_argument('--runold', action='store_true',
+        help='Force old tests to run ')
+
     # Per https://docs.python.org/2/library/argparse.html#partial-parsing, gather any known args. These will be passed to pytest.
     parsed_args, extra_args = parser.parse_known_args()
 
@@ -83,14 +86,7 @@ if __name__ == '__main__':
     else:
         # Make sure runestone_test is nice and clean -- this will remove many
         # tables that web2py will then re-create.
-        xqt('rsmanage --verbose initdb --reset --force',
-            'psql  --host={} --username={} {} < rtdata.sql'.format(pgnetloc, pguser, dbname))
-
-        if parsed_args.rebuildgrades:
-            with pushd('../../..'):
-                print("recalculating grades tables")
-                # TODO: This causes test failures when run.
-                xqt('{} web2py.py -S runestone -M -R applications/runestone/tests/make_clean_db_with_grades.py'.format(sys.executable))
+        xqt('rsmanage --verbose initdb --reset --force')
 
         # Copy the test book to the books directory.
         rmtree('../books/test_course_1', ignore_errors=True)
@@ -119,8 +115,21 @@ if __name__ == '__main__':
         xqt('{} -m coverage erase'.format(sys.executable),
             '{} -m pytest -v applications/runestone/tests/test_dashboard.py applications/runestone/tests/test_server.py {}'.format(sys.executable, ' '.join(extra_args)),
         )
-        if '-k' not in extra_args:
+
+    if '-k' not in extra_args or parsed_args.runold:
+        xqt('rsmanage initdb --reset --force')
+        xqt('psql  --host={} --username={} {} < rtdata.sql'.format(pgnetloc, pguser, dbname))
+        with pushd('../../..'):
             xqt(*['{} -m coverage run --append --source={} web2py.py -S runestone -M -R applications/runestone/tests/{}'.format(sys.executable, COVER_DIRS, x)
                 for x in ['test_ajax.py', 'test_admin.py', 'test_assignments.py']]
             )
-        xqt('{} -m coverage report'.format(sys.executable))
+            xqt('{} -m coverage report'.format(sys.executable))
+
+        # This pushes this back to the old way that justs makes sure the
+        # rebuilding the grades works... IWe could move this up a few lines if
+        # it turns out there is an advantage to being able to do this before running the old tests
+        if parsed_args.rebuildgrades:
+            with pushd('../../..'):
+                print("recalculating grades tables")
+                # TODO: This causes test failures when run.
+                xqt('{} web2py.py -S runestone -M -R applications/runestone/tests/make_clean_db_with_grades.py'.format(sys.executable))

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -118,6 +118,6 @@ if __name__ == '__main__':
         xqt('{} -m coverage erase'.format(sys.executable),
             '{} -m pytest -v applications/runestone/tests/test_server.py {}'.format(sys.executable, ' '.join(extra_args)),
             *['{} -m coverage run --append --source={} web2py.py -S runestone -M -R applications/runestone/tests/{}'.format(sys.executable, COVER_DIRS, x)
-              for x in ['test_ajax.py', 'test_admin.py', 'test_assignments.py']]
+              for x in ['test_ajax.py', 'test_admin.py', 'test_dashboard.py', 'test_assignments.py']]
         )
         xqt('{} -m coverage report'.format(sys.executable))

--- a/tests/test_course_1/_sources/test_chapter_1/subchapter_b.rst
+++ b/tests/test_course_1/_sources/test_chapter_1/subchapter_b.rst
@@ -1,0 +1,14 @@
+Subchapter B
+============
+
+
+Lets add one activity to this Subchapter!
+
+.. mchoice:: subc_b_1
+   :answer_a: True
+   :answer_b: False
+   :correct: b
+   :feedback_a: It usually takes longer to read a program because the structure is as important as the content and must be interpreted in smaller pieces for understanding.
+   :feedback_b: It usually takes longer to read a program because the structure is as important as the content and must be interpreted in smaller pieces for understanding.
+
+   True or False:  Reading a program is like reading other kinds of text.

--- a/tests/test_course_1/_sources/test_chapter_1/toctree.rst
+++ b/tests/test_course_1/_sources/test_chapter_1/toctree.rst
@@ -6,3 +6,4 @@ Test chapter 1
    :maxdepth: 2
 
    subchapter_a
+   subchapter_b

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -28,15 +28,21 @@ class TestDashboardEndpoints(unittest.TestCase):
     def setUp(self):
         global request, session, auth
         request = Request(globals()) # Use a clean Request object
+        request.folder = "/srv/web2py/applications/runestone/"
         session = Session()
+        Auth.expiration = 3600
         auth = Auth(db, hmac_key=Auth.get_or_create_key())
         exec(compile(open("applications/runestone/controllers/dashboard.py").read(), "applications/runestone/controllers/dashboard.py", 'exec'), globals())
 
 
     def testStudentReport(self):
+        from gluon import current
         auth.login_user(db.auth_user(1674))
         session.auth = auth
         request.vars.id=auth.user.username
+        current.request = request
+        current.session = session
+        current.auth = auth
 
         res = studentreport()   #todo: if this is an endoint why does it not return json?
 
@@ -52,6 +58,9 @@ class TestDashboardEndpoints(unittest.TestCase):
         auth.login_user(db.auth_user(11))
         session.auth = auth
         request.vars.tablekind = 'sccount'
+        current.request = request
+        current.session = session
+        current.auth = auth
 
         res = subchapoverview()
         self.assertIsNotNone(res)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -28,14 +28,15 @@ class TestDashboardEndpoints(unittest.TestCase):
     def setUp(self):
         global request, session, auth
         request = Request(globals()) # Use a clean Request object
-        request.folder = "/srv/web2py/applications/runestone/"
         session = Session()
-        Auth.expiration = 3600
         auth = Auth(db, hmac_key=Auth.get_or_create_key())
         exec(compile(open("applications/runestone/controllers/dashboard.py").read(), "applications/runestone/controllers/dashboard.py", 'exec'), globals())
 
-
-    def testStudentReport(self):
+    ## TODO -rewrite these tests in the style of test_server...
+    # As it stands we can run one of the tests in this file which then
+    # messes up the Auth object for any other tests.  It seems better
+    # to spend time redoing the tests a better way than patching these.
+    def XXtestStudentReport(self):
         from gluon import current
         auth.login_user(db.auth_user(1674))
         session.auth = auth
@@ -55,6 +56,7 @@ class TestDashboardEndpoints(unittest.TestCase):
 
 
     def test_subchapoverview(self):
+        from gluon import current
         auth.login_user(db.auth_user(11))
         session.auth = auth
         request.vars.tablekind = 'sccount'

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,26 +1,18 @@
 #
-# Unit Tests for AJAX API endpoints
+# Unit Tests for DASHBOARD API endpoints
 # Set up the environment variables
 # WEB2PY_CONFIG=test
 # TEST_DBURL=postgres://user:pw@host:port/dbname
 #
 #
 # Run these from the main web2py directory with the command:
-# python web2py.py -S runestone -M -R applications/runestone/tests/test_dashboard.py
+#
 #
 
-import unittest
 import sys
-from bs4 import BeautifulSoup
-
-from gluon.globals import Request, Session
-from gluon.tools import Auth
-from six import StringIO
 
 import pytest
 import six
-
-from .utils import web2py_controller_import
 
 
 def test_student_report(test_client, runestone_db_tools, test_user, test_user_1):
@@ -61,3 +53,10 @@ def test_subchapteroverview(test_client, runestone_db_tools, test_user, test_use
                 test_client.validate('dashboard/subchapoverview','subc_b_1', data=dict(tablekind='dividnum'))
                 test_client.validate('dashboard/subchapoverview','div_id', data=dict(tablekind='dividmin'))
                 test_client.validate('dashboard/subchapoverview','div_id', data=dict(tablekind='dividmax'))
+
+
+# TODO:
+# grades
+# questiongrades
+# exercisemetrics
+# better testing of index conten

--- a/views/dashboard/exercisemetrics.html
+++ b/views/dashboard/exercisemetrics.html
@@ -8,6 +8,7 @@
 <script src="{{=URL('static', 'dashboard-charts.js')}}"></script>
 
 <div id="dashboard">
+	{{ import six }}
 	<h1>{{=course.course_name}} <span class="dash-title-description">Instructor Dashboard</span></h1>
 	<h3>{{=exercise_label}}</h3>
 	<div>


### PR DESCRIPTION
Move db_dashboard.py to modules so it is not loaded on every request.

There are challenges with moving something like this to a module in that you need to use the `gluon.current` object to get at request, and db, etc.

The old unit tests are totally unable to cope with this craziness so I've disabled the two unit tests in test_dashboard.py (I've tested them extensively from the browser) and I'm going to write them in the style of test_server.py

@bjones1 my hand testing of these thing uncovered a problem with your utility function `get_course_row` by default it only returns a couple of columns from courses but anything that uses the `_sphinx_static_files.html` template will need much more.  I fixed the calls in dashboard.py to pass `db.courses.ALL` but there may be other problems lurking.... 