### PR TITLE
Fix: Correct Docker permissions.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -254,7 +254,7 @@ Controllers are reloaded automatically every time they are used.  However if you
 
 ### 8. File Permissions (especially on Linux)
 
-File permissions can seem a little strange when you start this container on linux.  Primarily because both nginx and uwsgi run as the `www-data` user.  So you will suddenly find your files under RunestoneServer owned by `www-data` . The best thing to do is to make sure that the files are in your group `chgrp -R <username> RunestoneServer` should allw both you and the container enough privileges to do your work.
+File permissions can seem a little strange when you start this container on Linux.  Primarily because both nginx and uwsgi run as the `www-data` user.  So you will suddenly find your files under RunestoneServer owned by `www-data` . The container's entrypoint script updates permissions to allow both you and the container enough privileges to do your work.
 
 ## Debugging
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -105,7 +105,14 @@ esac
 info "Updating file ownership"
 chown -R www-data /srv/web2py
 mkdir -p /run/uwsgi
+mkdir -p ${RUNESTONE_PATH}/databases
+chown www-data ${RUNESTONE_PATH}/databases
 chown -R www-data /run/uwsgi
+
+# For development, make all files group-writeable.
+if [ $WEB2PY_CONFIG == "development" ]; then
+    chmod -R g+w ${RUNESTONE_PATH}
+fi
 
 
 # Setup instructors, if the file exists


### PR DESCRIPTION
Tested on Ubuntu 18. I tested this on a clean VM; these changes allows git operations to work after Docker is running.