### PR TITLE
Allow instructor to rename Assignments on assignments tab.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1173,23 +1173,32 @@ function menu_from_editable(
 }
 
 
-// Invoked by the "Create" button of the "Create Assignment" dialog.
-function renameAssignment(id,form) {
+function fillinAssignmentName(target){
+    //On the assignments tab, fill in the target with the name of the current assignment
+    //Only used by the rename assignment button for now
+    select=$("#assignlist")[0]
+    $("#"+target).html(select.options[select.selectedIndex].innerHTML)
+}
+//Invoked by the "Rename" button of the "Rename Assignment" dialog
+function renameAssignment(form) {
+    var select=$("#assignlist")[0]
+    var id=select[select.selectedIndex].value
     var name = form.name.value;
     data={'name':name,'original':id}
     url='/runestone/admin/renameAssignment';
     jQuery.post(url,data,function(iserror,textStatus,whatever){
         if (iserror=="EXISTS"){
-            alert('There already is an assignment called "'+name+'".') //FIX: can I reopen the dialog box maybe? 
+            alert('There already is an assignment called "'+name+'".') //FIX: reopen the dialog box?
         } else if (iserror!='ERROR'){
             //find the assignment
-            select=document.getElementById('assignlist');
-            select.options[select.selectedIndex].innerHTML=name //FIX? make sure select.selectedIndex==original?
+            select=$('#assignlist')[0];
+            select.options[select.selectedIndex].innerHTML=name
         } else {
             alert('Error in renaming assignment '+id)
         }
     },'json')
 }
+// Invoked by the "Create" button of the "Create Assignment" dialog.
 function createAssignment(form) {
     var name = form.name.value;
 
@@ -1198,7 +1207,7 @@ function createAssignment(form) {
     url = '/runestone/admin/createAssignment';
     jQuery.post(url, data, function (iserror, textStatus, whatever) {
         if (iserror=="EXISTS"){
-            alert('There already is an assignment called "'+name+'".') //FIX: can I reopen the dialog box maybe? 
+            alert('There already is an assignment called "'+name+'".') //FIX: reopen the dialog box?
         } else if (iserror!='ERROR'){
                 select = document.getElementById('assignlist');
                 newopt = document.createElement('option');

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1174,6 +1174,22 @@ function menu_from_editable(
 
 
 // Invoked by the "Create" button of the "Create Assignment" dialog.
+function renameAssignment(id,form) {
+    var name = form.name.value;
+    data={'name':name,'original':id}
+    url='/runestone/admin/renameAssignment';
+    jQuery.post(url,data,function(iserror,textStatus,whatever){
+        if (iserror=="EXISTS"){
+            alert('There already is an assignment called "'+name+'".') //FIX: can I reopen the dialog box maybe? 
+        } else if (iserror!='ERROR'){
+            //find the assignment
+            select=document.getElementById('assignlist');
+            select.options[select.selectedIndex].innerHTML=name //FIX? make sure select.selectedIndex==original?
+        } else {
+            alert('Error in renaming assignment '+id)
+        }
+    },'json')
+}
 function createAssignment(form) {
     var name = form.name.value;
 
@@ -1181,7 +1197,9 @@ function createAssignment(form) {
     data = {'name': name}
     url = '/runestone/admin/createAssignment';
     jQuery.post(url, data, function (iserror, textStatus, whatever) {
-        if (iserror != 'ERROR') {
+        if (iserror=="EXISTS"){
+            alert('There already is an assignment called "'+name+'".') //FIX: can I reopen the dialog box maybe? 
+        } else if (iserror!='ERROR'){
                 select = document.getElementById('assignlist');
                 newopt = document.createElement('option');
                 newopt.value = iserror[name];

--- a/views/admin/assignments.html
+++ b/views/admin/assignments.html
@@ -63,13 +63,13 @@
 </div>
 
 <!-- Modal: Add -->
-<div aria-hidden="true" aria-labelledby="myModalLabel" class="modal fade" id="addAssignment" role="dialog" tabindex="-1">
+<div aria-hidden="true" aria-labelledby="myAddModalLabel" class="modal fade" id="addAssignment" role="dialog" tabindex="-1">
   <div class="modal-dialog">
     <div class="modal-content">
       <!-- Modal Header -->
       <div class="modal-header">
         <button class="close" data-dismiss="modal" type="button"><span aria-hidden="true">&times;</span> <span class="sr-only">Close</span></button>
-        <h4 class="modal-title" id="myModalLabel">Create Assignment</h4>
+        <h4 class="modal-title" id="myAddModalLabel">Create Assignment</h4>
       </div><!-- Modal Body -->
       <div class="modal-body">
         <form role="form">
@@ -87,18 +87,18 @@
 </div>
 
 <!-- Modal: Rename -->
-<div aria-hidden="true" aria-labelledby="myModalLabel" class="modal fade" id="renameAssignment" role="dialog" tabindex="-1">
+<div aria-hidden="true" aria-labelledby="myRenameModalLabel" class="modal fade" id="renameAssignment" role="dialog" tabindex="-1">
   <div class="modal-dialog">
     <div class="modal-content">
       <!-- Modal Header -->
       <div class="modal-header">
         <button class="close" data-dismiss="modal" type="button"><span aria-hidden="true">&times;</span> <span class="sr-only">Close</span></button>
-        <h4 class="modal-title" id="myModalLabel">Rename Assignment</h4>
+        <h4 class="modal-title" id="myRenameModalLabel">Rename Assignment</h4>
       </div><!-- Modal Body -->
       <div class="modal-body">
         <form role="form">
           <div class="form-group">
-            <label for="name">Enter the new name for assignment "<span id="renameName"></span>"</label> <input class="form-control" id="name" placeholder="Enter assignment name" type="text">
+            <label for="rename-name">Enter the new name for assignment "<span id="renameName"></span>"</label> <input class="form-control" id="rename-name" placeholder="Enter assignment name" type="text">
           </div>
           <input class="btn btn-default" data-dismiss="modal" onclick="renameAssignment(this.form)" type="button" value="Rename">
         </form>

--- a/views/admin/assignments.html
+++ b/views/admin/assignments.html
@@ -42,8 +42,9 @@
       <option value="{{=assignmentid}}">{{=assignments[assignmentid]}}</option>
       {{ pass }}
     </select>
-    <button class="btn" data-target="#addAssignment" data-toggle="modal" style="margin-top: 12px;">+</button>
-    <button class="btn" onclick="remove_assignment();" style="margin-top: 12px;">-</button>
+    <button class="btn" data-target="#addAssignment" data-toggle="modal" style="margin-top: 12px;">Add</button>
+    <button class="btn" onclick="remove_assignment();" style="margin-top: 12px;">Delete</button>
+    <button class="btn" data-target="#renameAssignment" data-toggle="modal" style="margin-top: 12px;">Rename</button>
     <fieldset>
       <legend>Assignment properties</legend>
       <span id="totalPoints"></span><br>
@@ -62,7 +63,7 @@
   <div class="col-md-2"></div>
 </div>
 
-<!-- Modal -->
+<!-- Modal: Add -->
 <div aria-hidden="true" aria-labelledby="myModalLabel" class="modal fade" id="addAssignment" role="dialog" tabindex="-1">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -80,11 +81,37 @@
         </form>
       </div><!-- Modal Footer -->
       <div class="modal-footer">
-        <button class="btn btn-default" data-dismiss="modal" type="button">Close</button>
+        <button class="btn btn-default" data-dismiss="modal" type="button">Cancel</button>
       </div>
     </div>
   </div>
 </div>
+
+<!-- Modal: Rename -->
+<div aria-hidden="true" aria-labelledby="myModalLabel" class="modal fade" id="renameAssignment" role="dialog" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <!-- Modal Header -->
+      <div class="modal-header">
+        <button class="close" data-dismiss="modal" type="button"><span aria-hidden="true">&times;</span> <span class="sr-only">Close</span></button>
+        <h4 class="modal-title" id="myModalLabel">Rename Assignment</h4>
+      </div><!-- Modal Body -->
+      <div class="modal-body">
+        <form role="form">
+          <div class="form-group">
+            <label for="name">Enter the new name for assignment "{{=assignments[assignmentid]}}"</label> <input class="form-control" id="name" placeholder="Enter assignment name" type="text">
+          </div>
+          <input class="btn btn-default" data-dismiss="modal" onclick="renameAssignment({{=assignmentid}},this.form)" type="button" value="Rename">
+        </form>
+      </div><!-- Modal Footer -->
+      <div class="modal-footer">
+        <button class="btn btn-default" data-dismiss="modal" type="button">Cancel</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+
 
 <div class="row">
   <div class="col-md-12" id="leftpanel2" style="visibility: hidden">

--- a/views/admin/assignments.html
+++ b/views/admin/assignments.html
@@ -32,7 +32,6 @@
 </script>
 <script src="{{=URL('static', 'js/bootstrap-table/bootstrap-table-reorder-rows.js')}}">
 </script>
-
 <div class="row">
   <div class="col-md-2"></div>
   <div class="col-md-8">
@@ -44,7 +43,7 @@
     </select>
     <button class="btn" data-target="#addAssignment" data-toggle="modal" style="margin-top: 12px;">Add</button>
     <button class="btn" onclick="remove_assignment();" style="margin-top: 12px;">Delete</button>
-    <button class="btn" data-target="#renameAssignment" data-toggle="modal" style="margin-top: 12px;">Rename</button>
+    <button class="btn" data-target="#renameAssignment" data-toggle="modal" onclick="fillinAssignmentName('renameName');" style="margin-top: 12px;">Rename</button>
     <fieldset>
       <legend>Assignment properties</legend>
       <span id="totalPoints"></span><br>
@@ -99,9 +98,9 @@
       <div class="modal-body">
         <form role="form">
           <div class="form-group">
-            <label for="name">Enter the new name for assignment "{{=assignments[assignmentid]}}"</label> <input class="form-control" id="name" placeholder="Enter assignment name" type="text">
+            <label for="name">Enter the new name for assignment "<span id="renameName"></span>"</label> <input class="form-control" id="name" placeholder="Enter assignment name" type="text">
           </div>
-          <input class="btn btn-default" data-dismiss="modal" onclick="renameAssignment({{=assignmentid}},this.form)" type="button" value="Rename">
+          <input class="btn btn-default" data-dismiss="modal" onclick="renameAssignment(this.form)" type="button" value="Rename">
         </form>
       </div><!-- Modal Footer -->
       <div class="modal-footer">


### PR DESCRIPTION
1) Allow instructor to rename Assignments on assignments tab, using a modal dialog that is similar to the createAssignment dialog.
2) Prevent two assignments from having the same name in the same course (either when creating or renaming an assignment).
3) Change the label on the "Close" button on the modal dialogs in the assignments tab to "Cancel", for clarity. (I wasn't sure if Close meant "do this and then close" or "close instead of doing this")
4) Change the + and - buttons to "Add" and "Delete" for clarity (and to match the new "Rename" button). 