### PR TITLE
Option to hide the Student Activity panel on Dashboard

### DIFF
--- a/models/db.py
+++ b/models/db.py
@@ -292,3 +292,13 @@ def check_for_donate_or_build(field_dict,id_of_insert):
 
 if 'auth_user' in db:
     db.auth_user._after_insert.append(check_for_donate_or_build)
+
+auth.settings.actions_disabled.append('register')
+
+auth.settings.actions_disabled.append('register')
+
+auth.settings.actions_disabled.append('register')
+
+auth.settings.actions_disabled.append('register')
+
+auth.settings.actions_disabled.append('register')

--- a/models/db.py
+++ b/models/db.py
@@ -292,13 +292,3 @@ def check_for_donate_or_build(field_dict,id_of_insert):
 
 if 'auth_user' in db:
     db.auth_user._after_insert.append(check_for_donate_or_build)
-
-auth.settings.actions_disabled.append('register')
-
-auth.settings.actions_disabled.append('register')
-
-auth.settings.actions_disabled.append('register')
-
-auth.settings.actions_disabled.append('register')
-
-auth.settings.actions_disabled.append('register')

--- a/views/dashboard/index.html
+++ b/views/dashboard/index.html
@@ -142,6 +142,7 @@
 				Class Activity
 				<button id="allTime" onclick="getActivity(false)" disabled>All Time</button>
 				<button id="lastWeek" onclick="getActivity(true);">Last 7 Days</button>
+                                <button id="hideStudent">Toggle Visibility</button>
 			</div>
 			<div class="dash-section-content">
 				<!-- <div style="text-align: right"><b>Sort by</b>

--- a/views/dashboard/index.html
+++ b/views/dashboard/index.html
@@ -142,9 +142,10 @@
 				Class Activity
 				<button id="allTime" onclick="getActivity(false)" disabled>All Time</button>
 				<button id="lastWeek" onclick="getActivity(true);">Last 7 Days</button>
-                                <button id="hideStudent">Toggle Visibility</button>
+                                <button id="hideStudent" data-target="#classactivitycontent" data-toggle="collapse"  >Hide/Show</button>
 			</div>
-			<div class="dash-section-content">
+                        <!--NOTE: If switch to Bootstrap 4.0, replace in with show-->
+			<div id="classactivitycontent" class="dash-section-content collapse in">
 				<!-- <div style="text-align: right"><b>Sort by</b>
 					<select name="activity-sortby">
 					  <option value="missed" selected>Alphabetical</option>


### PR DESCRIPTION
Adds a Hide/Show button to the Dashboard Student Activity panel, so that instructors can show the donut graphs to students in class without revealing personal student information.