### PR TITLE
Fix: Import datetime and use it consistently.

### DIFF
--- a/controllers/books.py
+++ b/controllers/books.py
@@ -20,6 +20,7 @@ import os
 import posixpath
 import json
 import logging
+import datetime
 
 logger = logging.getLogger(settings.logger)
 logger.setLevel(settings.log_level)

--- a/models/grouped_assignments.py
+++ b/models/grouped_assignments.py
@@ -1,6 +1,3 @@
-import datetime
-
-
 db.define_table('assignments',
     Field('course', db.courses),
     Field('name', 'string'),

--- a/rsmanage/grade.py
+++ b/rsmanage/grade.py
@@ -1,5 +1,5 @@
 from rs_grading import do_autograde, do_calculate_totals
-import json, datetime, sys
+import json
 
 userinfo = json.loads(os.environ['RSM_USERINFO'])
 # print(userinfo['course'], userinfo['pset'])


### PR DESCRIPTION
This removes unused imports, and add a missing `import datetime` in books.py to help avoid web2py bugs associated with its weird import system.