### PR TITLE
no need to set content_type (which should have been capitalized)

### DIFF
--- a/controllers/ajax.py
+++ b/controllers/ajax.py
@@ -187,7 +187,7 @@ def hsblog():
     return json.dumps(res)
 
 def runlog():    # Log errors and runs with code
-    response.headers['content-type'] = 'application/json'
+    # response.headers['content-type'] = 'application/json'
     setCookie = False
     if auth.user:
         sid = auth.user.username


### PR DESCRIPTION

jscript now visits runlog.json (PR to Runestone Components). This solves one instance of the bug found where content-type header was not capitalized, but some servers were treating it as json anyway.