### PR TITLE
plug holes in session expirations

### DIFF
--- a/controllers/ajax.py
+++ b/controllers/ajax.py
@@ -293,6 +293,9 @@ def hsblog():
         response.cookies["ipuser"] = sid
         response.cookies["ipuser"]["expires"] = 24 * 3600 * 90
         response.cookies["ipuser"]["path"] = "/"
+        response.cookies["last_course"] = auth.user.course_name
+        response.cookies["last_course"]["expires"] = 24 * 3600 * 90
+        response.cookies["last_course"]["path"] = "/"
 
     return json.dumps(res)
 


### PR DESCRIPTION
This addresses issues where the session cookie times out but the page is not reloaded.  So the eBookConfig.isLoggedIn value is true, but the session cookie has expired.

This also addresses the issue where you have multiple tabs open and change courses in one tab but come back to a previous tab.  Now your current course for the session does not match the course of the book you are displaying.

This also restores the commented out functionality of the idle timer reloading the page, which does seem to work nicely and forces the user to login again when the session expires.

This needs the support of the companion PR on RunestoneComponents

@bjones1 - The most confusing case is when a student logs in to course "babyfopp" a child course of fopp.  Then makes a bookmark -- But the bookmarked url is for books/published/fopp instead of books/published/babyfopp  This allows the student to access fopp.  -- So I'm trying to make it highly apparent that they are in the wrong place by graying out the progress bar.  The mark complete button is already hidden in this case.  But I wonder if there isn't something more clever we could do with url rewriting to make an initial bookmark with the correct course in the path.

