### PR TITLE
Added tests for edit_question endpoint

### DIFF
--- a/controllers/admin.py
+++ b/controllers/admin.py
@@ -1310,7 +1310,7 @@ def edit_question():
     )
 
     if not old_question:
-        return "Could not find question {} to update".format(old_qname)
+        return json.dumps("Could not find question {} to update".format(old_qname))
 
     author = auth.user.first_name + " " + auth.user.last_name
     timestamp = datetime.datetime.utcnow()
@@ -1322,12 +1322,12 @@ def edit_question():
     htmlsrc = vars["htmlsrc"]
 
     if old_qname == new_qname and old_question.author != author:
-        return "You do not own this question, Please assign a new unique id"
+        return json.dumps("You do not own this question, Please assign a new unique id")
 
     if old_qname != new_qname:
         newq = db(db.questions.name == new_qname).select().first()
         if newq and newq.author != author:
-            return "You cannot replace a question you did not author"
+            return json.dumps("You cannot replace a question you did not author")
 
     autograde = ""
     if re.search(r":autograde:\s+unittest", question):
@@ -1355,10 +1355,10 @@ def edit_question():
                 logger.error("TAG = %s", tag)
                 tag_id = db(db.tags.tag_name == tag).select(db.tags.id).first().id
                 db.question_tags.insert(question_id=new_qid, tag_id=tag_id)
-        return "Success - Edited Question Saved"
+        return json.dumps("Success - Edited Question Saved")
     except Exception as ex:
         logger.error(ex)
-        return "An error occurred saving your question {}".format(str(ex))
+        return json.dumps("An error occurred saving your question {}".format(str(ex)))
 
 
 @auth.requires(


### PR DESCRIPTION
This commit adds unit tests for the edit_question endpoint in admin.py, in reference to #1070 and #1259 
In order to create tests in line with other tests in the suite, edit_question needed to be modified to add `json.dumps()` calls surrounding all outputs. As otherwise `json.loads()` would fail on the test.
This change only applies to edit_question and should not affect the usage of the interface.