### PR TITLE
deleting a user takes a LONG time do it in the bg

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -5,6 +5,7 @@ import requests
 from six.moves.urllib.parse import unquote
 from six.moves.urllib.error import HTTPError
 import logging
+import subprocess
 
 from gluon.restricted import RestrictedError
 from stripe_form import StripeForm
@@ -625,21 +626,11 @@ def delete():
         )
         session.flash = "Account Deleted"
         db(db.auth_user.id == auth.user.id).delete()
-        db(db.useinfo.sid == auth.user.username).delete()
-        db(db.code.sid == auth.user.username).delete()
-        db(db.acerror_log.sid == auth.user.username).delete()
-        for t in [
-            "clickablearea",
-            "codelens",
-            "dragndrop",
-            "fitb",
-            "lp",
-            "mchoice",
-            "parsons",
-            "shortanswer",
-        ]:
-            db(db["{}_answers".format(t)].sid == auth.user.username).delete()
-
+        subprocess.call(
+            "rsmanage rmuser --username {} &".format(auth.user.username),
+            shell=True,
+            close_fds=True,
+        )
         auth.logout()  # logout user and redirect to home page
     else:
         redirect(URL("default", "user/profile"))

--- a/rsmanage/rsmanager.py
+++ b/rsmanage/rsmanager.py
@@ -563,6 +563,32 @@ def resetpw(config, username, password):
 
 
 @cli.command()
+@click.option("--username", help="Username, must be unique")
+@pass_config
+def rmuser(config, username):
+    """Utility to change a users password. Useful If they can't do it through the normal mechanism"""
+    os.chdir(findProjectRoot())
+    sid = username or click.prompt("Username")
+
+    eng = create_engine(config.dburl)
+    eng.execute("delete from auth_user where username = %s", sid)
+    eng.execute("delete from useinfo where sid = %s", sid)
+    eng.execute("delete from code where sid = %s", sid)
+    eng.execute("delete from acerror_log where sid = %s", sid)
+    for t in [
+        "clickablearea",
+        "codelens",
+        "dragndrop",
+        "fitb",
+        "lp",
+        "mchoice",
+        "parsons",
+        "shortanswer",
+    ]:
+        eng.execute("delete from {}_answers where sid = '{}'".format(t, sid))
+
+
+@cli.command()
 @click.option("--checkdb", is_flag=True, help="check state of db and databases folder")
 @pass_config
 def env(config, checkdb):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,7 @@ from textwrap import dedent
 import json
 from threading import Thread
 import datetime
+import time
 
 # Third-party imports
 # -------------------
@@ -798,6 +799,7 @@ def test_deleteaccount(test_client, runestone_db_tools, test_user):
     db = runestone_db_tools.db
     res = db(db.auth_user.username == "user_to_delete").select().first()
     print(res)
+    time.sleep(2)
     assert not db(db.useinfo.sid == "user_to_delete").select().first()
     assert not db(db.code.sid == "user_to_delete").select().first()
     assert not db(db.acerror_log.sid == "user_to_delete").select().first()


### PR DESCRIPTION
Users were reporting a 502 gateway timeout when trying to use the self deletion option.

Investigation showed that deleting entries from useinfo and acerror_log is VERY slow due to constraint enforcement.

This does most of the work in the background.
 