### PR TITLE
Fix: Generate HTML when sending a password reset e-mail.

### DIFF
--- a/models/db.py
+++ b/models/db.py
@@ -355,6 +355,7 @@ db.define_table(
 mail.settings.server = settings.email_server
 mail.settings.sender = settings.email_sender
 mail.settings.login = settings.email_login
+auth.messages.reset_password = '<html>Click on <a href="%(link)s">this link</a> to reset your password.</html>'
 
 # Make sure the latest version of admin is always loaded.
 adminjs = os.path.join("applications", request.application, "static", "js", "admin.js")


### PR DESCRIPTION
This helps with annoying tools like Cisco's link renamer, which breaks URLs in Runestone password reset e-mail that are sent as plain text.