### PR TITLE
Fix typo in login page

### DIFF
--- a/controllers/books.py
+++ b/controllers/books.py
@@ -106,7 +106,7 @@ def _route_book(is_published=True):
             if last_base and last_base.base_course == base_course:
                 # The user is trying to access the base course for the last course they logged in to
                 # there is a 99% chance this is an error and we should make them log in.
-                session.flash = "You Most likely want to log in to access your course"
+                session.flash = "You most likely want to log in to access your course"
                 redirect(URL(c="default", f="courses"))
 
         course = (


### PR DESCRIPTION
The message "You Most likely want to log in to access your course" was fixed to lowercase the "Most" in the sentence in the login page.