### PR TITLE
Fix: Use Sphinx section numbers, not Runestone chapter/subchapter numbers.

### DIFF
--- a/controllers/admin.py
+++ b/controllers/admin.py
@@ -1711,12 +1711,12 @@ def _get_toc_and_questions():
     for ch in chapters_query:
         q_ch_info = {}
         question_picker.append(q_ch_info)
-        q_ch_info["text"] = "{}. {}".format(ch.chapter_num, ch.chapter_name)
+        q_ch_info["text"] = ch.chapter_name
         q_ch_info["children"] = []
         # Copy the same stuff for reading picker.
         r_ch_info = {}
         reading_picker.append(r_ch_info)
-        r_ch_info["text"] = "{}. {}".format(ch.chapter_num, ch.chapter_name)
+        r_ch_info["text"] = ch.chapter_name
         r_ch_info["children"] = []
         # practice_questions = db((db.questions.chapter == ch.chapter_label) & \
         #                         (db.questions.practice == True))
@@ -1733,9 +1733,7 @@ def _get_toc_and_questions():
         for sub_ch in subchapters_query:
             q_sub_ch_info = {}
             q_ch_info["children"].append(q_sub_ch_info)
-            q_sub_ch_info["text"] = "{}.{} {}".format(
-                ch.chapter_num, sub_ch.sub_chapter_num, sub_ch.sub_chapter_name
-            )
+            q_sub_ch_info["text"] = sub_ch.sub_chapter_name
             # Make the Exercises sub-chapters easy to access, since user-written problems will be added there.
             if sub_ch.sub_chapter_name == "Exercises":
                 q_sub_ch_info["id"] = ch.chapter_name + " Exercises"
@@ -1751,9 +1749,7 @@ def _get_toc_and_questions():
                 r_sub_ch_info["id"] = "{}/{}".format(
                     ch.chapter_name, sub_ch.sub_chapter_name
                 )
-                r_sub_ch_info["text"] = "{}.{} {}".format(
-                    ch.chapter_num, sub_ch.sub_chapter_num, sub_ch.sub_chapter_name
-                )
+                r_sub_ch_info["text"] = sub_ch.sub_chapter_name
 
             author = auth.user.first_name + " " + auth.user.last_name
             questions_query = db(

--- a/controllers/books.py
+++ b/controllers/books.py
@@ -267,7 +267,6 @@ def _subchaptoc(course, chap):
         & (db.chapters.course_id == course)
         & (db.chapters.chapter_label == chap)
     ).select(
-        db.chapters.chapter_label,
         db.sub_chapters.sub_chapter_label,
         db.sub_chapters.sub_chapter_name,
         orderby=db.sub_chapters.sub_chapter_num,
@@ -276,8 +275,8 @@ def _subchaptoc(course, chap):
     )
     toclist = []
     for row in res:
-        sc_url = "{}.html".format(row.sub_chapters.sub_chapter_label)
-        title = row.sub_chapters.sub_chapter_name
+        sc_url = "{}.html".format(row.sub_chapter_label)
+        title = row.sub_chapter_name
         toclist.append(dict(subchap_uri=sc_url, title=title))
 
     return toclist

--- a/controllers/books.py
+++ b/controllers/books.py
@@ -267,8 +267,6 @@ def _subchaptoc(course, chap):
         & (db.chapters.course_id == course)
         & (db.chapters.chapter_label == chap)
     ).select(
-        db.chapters.chapter_num,
-        db.sub_chapters.sub_chapter_num,
         db.chapters.chapter_label,
         db.sub_chapters.sub_chapter_label,
         db.sub_chapters.sub_chapter_name,
@@ -279,11 +277,7 @@ def _subchaptoc(course, chap):
     toclist = []
     for row in res:
         sc_url = "{}.html".format(row.sub_chapters.sub_chapter_label)
-        title = "{}.{} {}".format(
-            row.chapters.chapter_num,
-            row.sub_chapters.sub_chapter_num,
-            row.sub_chapters.sub_chapter_name,
-        )
+        title = row.sub_chapters.sub_chapter_name
         toclist.append(dict(subchap_uri=sc_url, title=title))
 
     return toclist

--- a/models/db_ebook_chapters.py
+++ b/models/db_ebook_chapters.py
@@ -17,7 +17,6 @@ db.define_table(
     "sub_chapters",
     Field("sub_chapter_name", "string"),  # can have spaces in it, for human consumption
     Field("chapter_id", "reference chapters"),
-    Field("sub_chapter_length", "integer"),
     Field("sub_chapter_label", "string"),  # no spaces, actual filename path
     Field(
         "skipreading", "boolean"


### PR DESCRIPTION
This should be merged after https://github.com/RunestoneInteractive/RunestoneComponents/pull/1017. It uses Sphinx section numbers which that PR assigns.

I didn't update the use of `chapter_num` and `sub_chatper_num` in `dashboard.py`, a place I fear to tread...