### PR TITLE
Adding back "&& \" at end of line 66 to resolve unknown UNZIP instruction error during "docker build -t runestone/server .", and also adding some clarification for RunestoneServer Windows install instructions - Vincent Qiu (October 2020)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Chromedriver. Based on https://tecadmin.net/setup-selenium-with-chromedriver-on-debian/.
-RUN wget https://chromedriver.storage.googleapis.com/85.0.4183.87/chromedriver_linux64.zip
+RUN wget https://chromedriver.storage.googleapis.com/85.0.4183.87/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip && \
     mv chromedriver /usr/bin/chromedriver && \
     chown root:root /usr/bin/chromedriver && \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,13 +55,19 @@ Installation
 
    **Windows**
 
-   On Windows machines, install `PostgreSQL for Windows <https://www.postgresql.org/download/windows/>`_. (Tested with the EnterpriseDB interactive installer for PostgreSQL v 9.6).
+   On Windows machines, install `PostgreSQL for Windows <https://www.postgresql.org/download/windows/>`_. (Tested with the EnterpriseDB interactive installer for PostgreSQL v 9.6). Optionally, you can add the PostgreSQL bin folder (e.g. C:\Program Files\PostgreSQL\9.6\bin) to Path to make later steps slightly simpler:
+   
+     * Access the Environment Variables window: Control Panel > System and Security > System > Advanced System Settings > Advanced tab > Environment Variables (or Windows Search for "edit environment variables")
 
-#. Install web2py. The easiest way to do so is to download the **Source Code** distribution from http://www.web2py.com/init/default/download. `Here <http://www.web2py.com/examples/static/web2py_src.zip>`_ is a direct link to the zip archive. After you download it, extract the zip file to some folder on your hard drive. (web2py requires no real "installation").  I avoid the web2py.app installation on OS X as it messes with the Python path.  On Windows, the web2py.exe is also problematic because it won't find modules installed in a virtualenv.
+     * Either in User Variables (if you would like this addition to Path to be local to the current Windows user) or in System Variables (if you would like this addition to Path to apply to all users on your machine), click the Path line, and then click ``Edit...``.
 
-#. Get familiar with the Runestone Components, which were installed with pip. They come from https://github.com/RunestoneInteractive/RunestoneComponents and there are good quick start instructions there.
+     * Click ``New`` and paste the PostgreSQL bin folder directory.
 
-#. Clone this repository **into the web2py/applications directory**. If you might be contributing to the project, please fork this repository first and then do a local clone onto your machine, in the web2py/applications. You will contribute back to the project by making pull requests from your fork to this one.  When you make the clone you should clone it into ``runestone`` rather than the default ``RunestoneServer`` .  All the web2py stuff is configured assuming that the application will be called **runestone**.
+#. Install web2py. The easiest way to do so is to download the **Source Code** (NOT the binaries) distribution from http://www.web2py.com/init/default/download. `Here <http://www.web2py.com/examples/static/web2py_src.zip>`_ is a direct link to the zip archive. After you download it, extract the zip file to some folder on your hard drive. (web2py requires no real "installation").  I avoid the web2py.app installation on OS X as it messes with the Python path.  On Windows, the web2py.exe is also problematic because it won't find modules installed in a virtualenv.
+
+#. Get familiar with the Runestone Components, which were installed with pip. They come from https://github.com/RunestoneInteractive/RunestoneComponents and there are good quick start instructions there. If you might be contributing to RunestoneComponents as well, then please fork this repository and then do a local clone onto your machine, but clone it into a different directory than where you will clone RunestoneServer in the next step. For additional information on installing RunestoneComponents, please refer to the documentation included in that repository. If you do not clone a local copy of RunestoneComponents onto your machine, then the master version on GitHub will be used during server setup.
+
+#. Clone the https://github.com/RunestoneInteractive/RunestoneServer repository **into the web2py/applications directory**. If you might be contributing to the project, please fork this repository first and then do a local clone onto your machine, in the web2py/applications. You will contribute back to the project by making pull requests from your fork to this one.  When you make the clone you should clone it into ``runestone`` rather than the default ``RunestoneServer`` .  All the web2py stuff is configured assuming that the application will be called **runestone**.
 
    There are a couple of prerequisites you need to satisfy before you can build and use this
    eBook. The easiest/recommended way is to use `pip <http://www.pip-installer.org/en/latest/>`_. You can simply install all dependencies by running the following command in main runestone directory:
@@ -93,7 +99,7 @@ Installation
            Shall the new role be a superuser? (y/n) y
            Password: <password for the default, postgres user>
 
-     * For Windows, use the `-U postgres <https://www.postgresql.org/docs/9.6/static/app-createdb.html>`_ flag to run all commands in the ``postgres`` role, which is automatically created during installation.
+     * For Windows, the equivalent of the above is using the `-U postgres <https://www.postgresql.org/docs/9.6/static/app-createdb.html>`_ flag to run all commands in the ``postgres`` role, which is automatically created during installation.
 
        ::
 
@@ -104,7 +110,9 @@ Installation
            Shall the new role be a superuser? (y/n) y
            Password: <password for the default, postgres user>
 
-     * On both Mac and Ubuntu you can now do the following; for Windows, use ``"C:\Program Files\PostgreSQL\9.6\bin\createdb" --owner=<yournamehere> -U postgres runestone``. Enter the password for the default, postgres user (not for the newly-created user).
+       If you added PostgreSQL to Path, then you can simplify the above command to ``createuser --interactive -U postgres -P``.
+
+     * On both Mac and Ubuntu you can now do the following, and enter the password for the default, postgres user (not for the newly-created user). For Windows, the equivalent is to use ``"C:\Program Files\PostgreSQL\9.6\bin\createdb" --owner=<yournamehere> -U postgres runestone``. Again, if you added PostgreSQL to Path, then you can use the simplified command ``createdb --owner=<yournamehere> -U postgres runestone``.
 
    ::
 
@@ -124,9 +132,9 @@ Installation
    * Tell web2py to use that database:
 
      * If you're running https, edit ``settings.server_type`` in ``web2py/applications/runestone/models/0.py``.
-     * Set and export environment variable for DBURL -- Note the url format for web2py is different from sqlalchemy.  use `postgres` for web2py and `postgresql` for sqlalchemy.  example:  `postgresql://username:pw@host/database` where pw may be empty, and `database` is the database you created above, `runestone`.
-     * Set and export environment variable WEB2PY_CONFIG. If set to production, it will get the database connection string from DBURL. If set to development, it will get the database connection string from DEV_DBURL. If set to test, it will get it from TEST_DBURL.
-     * Set and export environment variable WEB2PY_MIGRATE. If set to Yes, web2py will check on each page load whether any database migrations are needed and perform them. If set to No, web2py will just assume that models match the database. If set to Fake, web2py will try to update the metadata it maintains about the database tables to match the models, but will not make any changes to the database; use that setting only for repairs when something has gone wrong.
+     * Set and export environment variable for ``DBURL`` -- Note the url format for web2py is different from sqlalchemy.  use `postgres` for web2py and `postgresql` for sqlalchemy.  example:  `postgresql://username:pw@host/database` where pw may be empty, and `database` is the database you created above, `runestone`.
+     * Set and export environment variable ``WEB2PY_CONFIG``. If set to production, it will get the database connection string from DBURL. If set to development, it will get the database connection string from DEV_DBURL. If set to test, it will get it from TEST_DBURL.
+     * Set and export environment variable ``WEB2PY_MIGRATE``. If set to Yes, web2py will check on each page load whether any database migrations are needed and perform them. If set to No, web2py will just assume that models match the database. If set to Fake, web2py will try to update the metadata it maintains about the database tables to match the models, but will not make any changes to the database; use that setting only for repairs when something has gone wrong.
      * If you want to customize other settings you can create a file ``applications/runestone/models/1.py`` using ``models/1.py.prototype`` as the template.  If you have your environment variables set up as explained above you probably won't need to worry about this for your initial setup.
 
    ::
@@ -137,7 +145,17 @@ Installation
        export TEST_DBURL=postgresql://username:pw@host/database
        export DEV_DBURL=postgresql://username:pw@host/database
 
-#. run `rsmanage initdb`  -- This will initialize the database so you can build your first book.  The rsmanage command was installed when you ran `pip install -r requirements.txt` in a previous step.  If you are upgrading you should run `pip install -e rsmanage` from the applications/runestone directory.
+     * For Windows, use the ``set`` command instead of ``export``, e.g. ``set WEB2PY_CONFIG=production``.
+     * You can confirm that you have set the environment variable and database connection string correctly using the following, and then to exit this command, use ``\q``.
+
+   ::
+
+       C:\> "C:\Program Files\PostgreSQL\9.6\bin\psql" %DBURL%
+       psql (9.6)
+       Type "help" for help.
+       runestone=# \q
+
+#. run ``rsmanage initdb``  -- This will initialize the database so you can build your first book.  The rsmanage command was installed when you ran ``pip install -r requirements.txt`` in a previous step.  If you are upgrading you should run ``pip install -e rsmanage`` from the applications/runestone directory. If you are developing and wanting to test a change, then use ``rsmanage initdb --reset`` to close and reinitialize the database, incorporating recent changes.
 
 
    .. important:: Database errors
@@ -145,7 +163,7 @@ Installation
       If you get an error message that the session table already exists, you need to go into the database and drop the table.
       If you get other error messages about tables that either exist or do not exist when they should or should not, then your database is out of sync with the data in your databases folder created by web2py.  This is not a happy spot to be in.  `rsmanage initdb --reset` will definitely get things back in order for a new installation.
 
-      If this is an old installation and you don't want to lose any data the you can try setting the `WEB2PY_MIGRATE` variable to 'Fake' But, this may cause cause even more problems, so only use it if you really know what changes you have made to the database schema and why.  You may need to study sql.log to figure out which tables need to be migrated by hand.
+      If this is an old installation and you don't want to lose any data the you can try setting the ``WEB2PY_MIGRATE`` variable to 'Fake' But, this may cause cause even more problems, so only use it if you really know what changes you have made to the database schema and why.  You may need to study sql.log to figure out which tables need to be migrated by hand.
 
 
 
@@ -177,10 +195,10 @@ More on Environment Variables
 
 There are a few environment variables that you can use to control the runestone server out of the box:
 
-* `WEB2PY_CONFIG` You can set this to production, development, or test.  Each mode can have a corresponding database connection environment variable.  They are:
-* for development use `DEV_DBURL`
-* for test use `TEST_DBURL`
-* for production use `DBURL`   Yes, its not quite consistent, but its backward compatible for the way we have been doing things.
+* ``WEB2PY_CONFIG`` You can set this to production, development, or test.  Each mode can have a corresponding database connection environment variable.  They are:
+* for development use ``DEV_DBURL``
+* for test use ``TEST_DBURL``
+* for production use ``DBURL``   Yes, its not quite consistent, but its backward compatible for the way we have been doing things.
 
 
 Create an account for yourself


### PR DESCRIPTION
https://github.com/RunestoneInteractive/RunestoneServer/commit/4e741bb632910bc5da8f861903e83e2d7aed9214#commitcomment-43114988
https://github.com/RunestoneInteractive/RunestoneServer/issues/1547

Change to Dockerfile was made on Sep 9 that removed `&&\` at end of line 66: https://github.com/RunestoneInteractive/RunestoneServer/commit/4e741bb632910bc5da8f861903e83e2d7aed9214

Without these characters, command `docker build -t runestone/server .` returns `failed to solve with frontend dockerfile.v0: failed to create LLB definition: Dockerfile parse error line 67: unknown instruction: UNZIP` and stops the build:
![image](https://user-images.githubusercontent.com/40499850/95928101-89011a00-0d8e-11eb-9833-de13aaa957ce.png)