### PR TITLE
Add total points to bottom of questions list

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -2356,3 +2356,16 @@ function copyElementToClipboard(elid) {
     document.execCommand("copy");
     document.body.removeChild(el);
 }
+
+$(document).ready(function() {
+    var totalPointsDiv = document.getElementById('totalPoints');
+    var totalPointsCopy = document.getElementById('totalPointsCopy');
+    var observer = new MutationObserver(function() {
+        totalPointsCopy.innerHTML = totalPointsDiv.innerHTML;
+    });
+    observer.observe(totalPointsDiv, {
+        attributes: true,
+        childList: true,
+        characterData: true
+    });
+});

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -2357,15 +2357,17 @@ function copyElementToClipboard(elid) {
     document.body.removeChild(el);
 }
 
-$(document).ready(function() {
-    var totalPointsDiv = document.getElementById('totalPoints');
-    var totalPointsCopy = document.getElementById('totalPointsCopy');
-    var observer = new MutationObserver(function() {
-        totalPointsCopy.innerHTML = totalPointsDiv.innerHTML;
+if (window.location.href.includes('runestone/admin/assignments')) {
+    $(document).ready(function() {
+        var totalPointsDiv = document.getElementById('totalPoints');
+        var totalPointsCopy = document.getElementById('totalPointsCopy');
+        var observer = new MutationObserver(function() {
+            totalPointsCopy.innerHTML = totalPointsDiv.innerHTML;
+        });
+        observer.observe(totalPointsDiv, {
+            attributes: true,
+            childList: true,
+            characterData: true
+        });
     });
-    observer.observe(totalPointsDiv, {
-        attributes: true,
-        childList: true,
-        characterData: true
-    });
-});
+}

--- a/views/admin/assignments.html
+++ b/views/admin/assignments.html
@@ -645,17 +645,6 @@ $(function () {
         },
     });
 });
-  
-var totalPointsDiv = document.getElementById('totalPoints');
-var totalPointsCopy = document.getElementById('totalPointsCopy');
-var observer = new MutationObserver(function() {
-  totalPointsCopy.innerHTML = totalPointsDiv.innerHTML;
-});
-observer.observe(totalPointsDiv, {
-  attributes: true,
-  childList: true,
-  characterData: true
-});
 </script>
 
 {{ end }}

--- a/views/admin/assignments.html
+++ b/views/admin/assignments.html
@@ -160,6 +160,7 @@
           <div class="panel-body">
             <p>Select the problems which compose this assignment.</p>
             <table id="questionTable" style="width:100%;"></table>
+            <span id="totalPointsCopy" style="margin-bottom: 10px;"></span><br>
             <div class="container">
               <div class="col-md-6">
               <a class="btn btn-default" data-toggle="tab" href="#qbrowse" id="browse-button">Browse</a>
@@ -643,6 +644,17 @@ $(function () {
             })
         },
     });
+});
+  
+var totalPointsDiv = document.getElementById('totalPoints');
+var totalPointsCopy = document.getElementById('totalPointsCopy');
+var observer = new MutationObserver(function() {
+  totalPointsCopy.innerHTML = totalPointsDiv.innerHTML;
+});
+observer.observe(totalPointsDiv, {
+  attributes: true,
+  childList: true,
+  characterData: true
 });
 </script>
 


### PR DESCRIPTION
Duplicate the total points that is near the top of the instructors' assignments admin page and places this copy at the bottom of the questions list. This is so that changes to the total points of an assignment can be more easily seen while making changes to an assignment's question list without needing to scroll back up to the top of the page.
![image](https://user-images.githubusercontent.com/40499850/112209121-803f2a80-8bef-11eb-976d-0ab7e1fa6f83.png)

See https://github.com/RunestoneInteractive/RunestoneComponents/issues/1143