### PR TITLE
Sort assignments list alphabetically in instructor's admin interface (quick fix temporary solution)

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1293,6 +1293,18 @@ function getAssignmentId() {
     return assignlist.options[assignlist.selectedIndex].value;
 }
 
+function assignListAlpha(assignlist) {
+    var currentAssignment = assignlist.value;
+    var options = $(assignlist).children().toArray();
+    options.sort(function(a,b) {
+        if (a.text.toUpperCase() > b.text.toUpperCase()) return 1;
+        else if (a.text.toUpperCase() < b.text.toUpperCase()) return -1;
+        else return 0;
+    });
+    $(assignlist).empty().append(options);
+    $(assignlist).val(currentAssignment);
+}
+
 // Given a selected assignment, retrieve it from the server then display it.
 function assignmentInfo() {
     // If no assignment is selected, hide all assignment-related panels.

--- a/views/admin/assignments.html
+++ b/views/admin/assignments.html
@@ -36,7 +36,7 @@
   <div class="col-md-2"></div>
   <div class="col-md-8">
     <h4 style="text-align: center;">Assignment</h4>
-    <select class="form-control" id="assignlist" onchange="assignmentInfo();">
+    <select class="form-control" id="assignlist" onfocus="assignListAlpha(this);" onchange="assignmentInfo();">
       {{ for assignmentid in assignments: }}
       <option value="{{=assignmentid}}">{{=assignments[assignmentid]}}</option>
       {{ pass }}


### PR DESCRIPTION
Addressing https://github.com/RunestoneInteractive/RunestoneServer/issues/1628 Sort the assignment alphabetically in the drop down list on the assignments page in the instructor's interface

Reorder the options in the assignment list select dropdown alphabetically while preserving their assignment ID and data. This is only meant to be a temporary quick fix that will be replaced by a better longer term solution.
![image](https://user-images.githubusercontent.com/40499850/113921888-97b41100-97b4-11eb-8a23-0192d32e07ae.png)