### PR TITLE
update restructuredText link and make it open in new tab

### DIFF
--- a/views/admin/assignments.html
+++ b/views/admin/assignments.html
@@ -315,7 +315,7 @@
                       <div class="col-md-12">
                         <label for="qcode"></label>
                         <textarea cols="65" form="newqform" id="qcode" name="editRST" rows="12"></textarea>
-                        <p>You are writing in <a href="https://www.sphinx-doc.org/en/latest/usage/restructuredtext/basics.html">restructuredText</a>, indentation matters.</p>
+                        <p>You are writing in <a href="https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html" target="_blank">restructuredText</a>, indentation matters.</p>
                       </div>
                       <div class="col-md-12">
                         <p id="qnameerror" style="color: red"></p>


### PR DESCRIPTION
Addressing https://github.com/RunestoneInteractive/RunestoneServer/issues/1591 "When writing a new activecode assignment I clicked on the link to the restructuredText documentation and it replaced the current page losing all my changes. You might think to change that link to open in a new tab."