### PR TITLE
#1783: Fixes spacing issue

### DIFF
--- a/views/default/user.html
+++ b/views/default/user.html
@@ -229,7 +229,7 @@
                                 }
                             }
                         </script>
-                        <p><strong>Important</strong> If you are an instructor please use your institutional email address so we can verify your instructor status.  If we cannot verify your status as an instructor your course will be removed.</p>
+                        <p><strong>Important:</strong> If you are an instructor please use your institutional email address so we can verify your instructor status.  If we cannot verify your status as an instructor your course will be removed.</p>
                         <form class="form-vertical" enctype="multipart/form-data" method="post" onsubmit="return checkTcp()">
                             <table>
                                 <tr id="auth_user_username__row">


### PR DESCRIPTION
Fixes issue #1783 

Changes the registration page to fix the previous spacing issue. It also adds a colon for readability. 

Previously was: ImportantIf you are an instructor

Now reads as: Important: If you are an instructor

Berea College student. 😄 