### PR TITLE
Better `ensure_in_docker`

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -115,6 +115,9 @@ jobs:
                     cd RunestoneServer
                     docker-compose up -d
                     docker-compose logs --follow &
+                    # Wait for the container to start and create a basic venv before running docker tools inside it.
                     sleep 5
-                    docker-tools wait
+                    # Invoke this directly, since the ``docker-tools`` script isn't installed yet.
+                    docker exec -t runestoneserver_runestone_1 bash -c "\$RUNESTONE_PATH/.venv/bin/python \$RUNESTONE_PATH/docker/docker_tools.py wait"
+                    # After this, the docker tools are installed.
                     docker-tools stop-servers

--- a/docker/docker_tools.py
+++ b/docker/docker_tools.py
@@ -50,7 +50,7 @@ from textwrap import dedent
 # Everything after this depends on Unix utilities.
 if sys.platform == "win32":
     print("Run this program in WSL/VirtualBox/VMWare/etc.")
-    # sys.exit()
+    sys.exit()
 
 
 # Check to see if a program is installed; if not, install it.
@@ -411,8 +411,12 @@ def build(
         browser = "chromium"
     # Add node.js per the `instructions <https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions>`_.
     xqt("curl -fsSL https://deb.nodesource.com/setup_current.x | bash -")
-    xqt("""echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list""")
-    xqt("wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -")
+    xqt(
+        """echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list"""
+    )
+    xqt(
+        "wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -"
+    )
     xqt(
         "apt-get update",
         "apt-get install -y --no-install-recommends eatmydata",

--- a/docker/docker_tools_misc.py
+++ b/docker/docker_tools_misc.py
@@ -193,10 +193,12 @@ def ensure_in_docker(
     # #.    Single-quote each argument before passing it.
     # #.    Run it in the venv used when building Docker, since this avoids installing click globally.
     # #.    Use env vars defined in the `../Dockerfile`, rather than hard-coding paths. We want these env vars evaluated after the shell in Docker starts, not now, hence the use of ``\$`` and the surrounding double quotes.
-    quoted_args = "' '".join(sys.argv[1:])
+    # #.    Use just the name, not the full path, of ``sys.argv[0]``, since the filesystem is different in Docker. We assume that this command will be either in the path (with the venv activated).
+    exec_name = Path(sys.argv[0]).name
+    quoted_args = "' '".join([exec_name] + sys.argv[1:])
     xqt(
         f"docker exec -{'i' if is_interactive else ''}t {runestone_container_name} bash -c "
-        '"\$RUNESTONE_PATH/.venv/bin/python \$RUNESTONE_PATH/docker/docker_tools.py '
+        '"source \$RUNESTONE_PATH/.venv/bin/activate; '
         f"'{quoted_args}'\""
     )
     sys.exit(0)


### PR DESCRIPTION
Fix: Allow ensure_in_docker to run any program in the Docker venv path, not just docker-tools.

Black cleanup