### PR TITLE
Issue #1750 Registration Warning Messages More Visible

### DIFF
--- a/views/default/user.html
+++ b/views/default/user.html
@@ -212,6 +212,16 @@
     <div class="content row">
     {{pass}}
         <!-- REGISTRATION -->
+        {{if form.errors: }}
+                            <div class="warning">
+                                <p style="color:red"><b>Please fix the following errors in your registration</b></p>
+                                <ul>
+                                    {{ for error in form.errors:}}
+                                        <li><b>{{=error}}:</b>  {{=form.errors[error]}}</li>
+                                    {{pass}}
+                                </ul>
+                            </div>
+                        {{pass}}
         {{if (request.args(0) == 'register'): }} <!-- register page -->
           {{if not settings.lti_only_mode:}}
             <div id="registration_div">
@@ -318,16 +328,6 @@
                                 });
                             </script>
                         {{=form.custom.end}}
-                        {{if form.errors: }}
-                            <div class="warning">
-                                <p><b>Please fix the following errors in your registration</b></p>
-                                <ul>
-                                    {{ for error in form.errors:}}
-                                        <li>{{=error}}:  {{=form.errors[error]}}</li>
-                                    {{pass}}
-                                </ul>
-                            </div>
-                        {{pass}}
                     </div> <!-- end form div -->
                 </div>
             </div> <!-- end register div -->


### PR DESCRIPTION
This PR fixes issue #1750 in RunestoneServer.
The warning messages of fields not being filled correctly in the user registration page, whether because they do not meet the requirements, passwords not matching, or username or email being used already; will be towards the top of the page, before the fields, and they're of more visible colors to bring more attention to it.
Files modified
- users.html