### PR TITLE
solve issue #1763 (update total point in gradebook dashboard)

### DIFF
--- a/controllers/assignments.py
+++ b/controllers/assignments.py
@@ -386,7 +386,6 @@ def record_grade():
 
     student_rownum = None
 
-
     # Update the score(s).
     try:
         # sid can be a list of sids to change. Walk through each element in the list.

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1754,6 +1754,10 @@ function renderGradingComponents(sid, divid) {
     let div = document.createElement("div");
     let grade = document.createElement("input");
     let gradelabel = document.createElement("label");
+    let url = new URL(window.location.href);
+    let assignmentid = url.searchParams.get("assignment_id");
+    // let assignmentid = GetUrlKeyValue("assignment_id", false, location.href);
+    console.log(assignmentid);
     gradelabel.for = "grade-input";
     $(gradelabel).text("Grade");
     grade.type = "text";
@@ -1775,6 +1779,7 @@ function renderGradingComponents(sid, divid) {
             type: "POST",
             dataType: "JSON",
             data: {
+                assignmentid: assignmentid,
                 acid: divid,
                 sid: sid,
                 grade: $(grade).val(),
@@ -1783,6 +1788,7 @@ function renderGradingComponents(sid, divid) {
             success: function (data) {
                 $(grade).css("background", "lightgreen");
                 $(comment).css("background", "lightgreen");
+                window.location.reload(true);
             },
         });
     });

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1756,8 +1756,6 @@ function renderGradingComponents(sid, divid) {
     let gradelabel = document.createElement("label");
     let url = new URL(window.location.href);
     let assignmentid = url.searchParams.get("assignment_id");
-    // let assignmentid = GetUrlKeyValue("assignment_id", false, location.href);
-    console.log(assignmentid);
     gradelabel.for = "grade-input";
     $(gradelabel).text("Grade");
     grade.type = "text";


### PR DESCRIPTION
@sreynit02 and I solved the issue #1763 making the following changes:
1. Pass assignment id with POST data object in admin.js
2. Validate new "assignmentid" parameter for the record_grade function
3. Gather assignment information
4. Call do_calculate_totals() in the record_grade function

This pull request was approved by Dr. Jan Pearce of Berea College.

**Screenshot walkthrough of the change**
The gradebook before instructor changes grade for assignment question:

![image](https://user-images.githubusercontent.com/63318355/144447827-f7baf2de-44f9-4c2e-aa2b-0e9b3962b301.png)

Question drilldown:

![image](https://user-images.githubusercontent.com/63318355/144448071-dc48ecb8-5bb4-4716-85dc-08f20ecd86aa.png)

Change point for first question from 0 to 1:

![image](https://user-images.githubusercontent.com/63318355/144448658-8fe36354-25f5-4c4b-8e8e-5469ab399068.png)

Point is updated in the question drilldown:

![image](https://user-images.githubusercontent.com/63318355/144448844-62221d15-abd7-4159-9122-988fd8cb97b2.png)

Now, the change to question points is also reflected in the gradebook (used to be 50%, now it's 100%, as expected):

![image](https://user-images.githubusercontent.com/63318355/144448927-2e27255e-1101-4fbc-88f5-1c79cd53c08c.png)

