### PR TITLE
Fix: Simplify the user-facing install process

### DIFF
--- a/docker/README.rst
+++ b/docker/README.rst
@@ -3,15 +3,7 @@ Docker Deployment
 
 .. TODO
 
-    Is there some way to simplify these instructions? It's still a long, error-prone process! Do we need another setup script that follows these directions and prompts the user for input (do you want to run the server or do development? What is your github userid? Etc.)? Such a script would be able to take care of the first 7 steps, which would be good progress. But, we'd need os-dependent stuff for the first bits (install WSL/Ubuntu on Windows); can we assume Python 3 on Mac?
-
-    Enable the script to download and install the Docker Desktop if necessary.
-
-        Blocker: how to determine if the Docker Desktop is installed in Windows? The discussion on `Poweruser <https://superuser.com/questions/68611/get-list-of-installed-applications-from-windows-command-line>`__ on WMIC didn't work for me.
-
-        Blocker: how to determine if OS X is running on x86 or M1? Python doesn't provide accurate info on older x86 versions of the code (see `SO <https://stackoverflow.com/questions/66842004/get-the-processor-type-using-python-for-apple-m1-processor-gives-me-an-intel-pro>`__). Using a specific library just to detect this seems like more trouble than it's worth.
-
-    TODO: Create a Windows batch file that checks for WSL and Ubuntu and installs them if not, then starts this script in Ubuntu.
+    See https://github.com/RunestoneInteractive/RunestoneServer/issues/1973 for ideas on how to improve this still-complex problem.
 
 
 .. note::
@@ -41,26 +33,21 @@ To build a Docker application with the server and all its dependencies:
 
     You will need to enter the root user password several times during the following steps. Look for the ``Password:`` prompt, then enter your password. Note that **no characters** will be echoed when you type your password -- this is a normal security precaution built into Unix.
 
+
 1. Install OS-dependent prerequisites
 *************************************
 
-Linux
-^^^^^
-If running on Linux, you must use Ubuntu 20.04 (although any version of Ubuntu 18.0+ should work). Installation on older versions of Ubuntu or other Linux distributions may require adjustments. Install ``curl`` by opening a terminal then typing:
-
-    .. code:: bash
-
-        sudo apt-get install -y curl
-
 OS X
 ^^^^
-If running on OS X, install then run the `Docker Desktop <https://www.docker.com/products/docker-desktop/>`_.
+Open a Terminal. In the Terminal:
+
+#.  `Install Homebrew <https://brew.sh/#install>`_.
+#.  Execute ``brew install python docker``.
+#.  Run the newly-installed Docker Desktop application.
 
     .. note::
 
         Expect to wait a few minutes the first time you start the Docker Desktop. Don't proceed until the Docker Desktop's initialization is complete.
-
-Next, `install Python 3 <https://docs.python-guide.org/starting/install3/osx/>`_.
 
 Windows
 ^^^^^^^
@@ -85,65 +72,47 @@ If running on Windows, either:
             HTTPS   TCP                     443                     443
             =====   ========    =======     =========   ========    ==========
 
-Next, install ``curl`` by opening an Ubuntu terminal then typing:
+Next, run the ``Ubuntu`` program to open a Linux terminal (if using WSL2) or boot up Linux and open a terminal (for VirtualBox or other virtualization software).
+
+Finally, follow the directions for Linux below.
+
+Linux
+^^^^^
+If running on Linux, you must use Ubuntu 20.04 (although any version of Ubuntu 18.0+ should work). Installation on older versions of Ubuntu or other Linux distributions may require adjustments. Install ``curl`` by opening a terminal then typing:
 
 .. code:: bash
 
-    sudo apt-get install -y curl
+    sudo apt install -y curl
+
+.. warning::
+
+    If this fails, run ``sudo apt update`` then retry the command above.
+
 
 2. Download the bootstrap script
 ********************************
-To keep your filesystem tidy, create a directory before running the following commands, since these commands download several scripts and subdirectories. To do this:
-
-    .. code-block:: bash
-
-        mkdir rsdocker
-        cd rsdocker
-
 .. note::
 
     On OS X, avoid placing your files in the Documents folder, since security features introduced in OS X 12.4 require you to give Docker `additional permissions <https://support.apple.com/guide/mac-help/control-access-to-files-and-folders-on-mac-mchld5a35146/mac>`_.
 
-Next, download the bootstrap script. To do this, open a terminal in Ubuntu or OS X then type:
+Download the bootstrap script. To do this, open a terminal in Ubuntu or OS X then type:
 
 .. code-block:: bash
 
     curl -fLO https://raw.githubusercontent.com/RunestoneInteractive/RunestoneServer/master/docker/docker_tools.py
 
-This downloads the bootstrap script.
 
-
-3. Create then activate a Python virtual environment
-****************************************************
-A Python virtual environment ensures that all the Python dependencies installed by this process don't interfere with your global / system Python installation.
-
-#.  `Create a Python virtual environment <https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment>`_ named ``rsvenv`` (RuneStone Virtual ENVironment):
-
-    .. code-block:: bash
-
-        python3 -m venv rsvenv
-
-#.  `Activate the virtual environment <https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#activating-a-virtual-environment>`_ you just created.
-
-    On Windows:
-
-        .. code-block:: bash
-
-            rsvenv\Scripts\activate
-
-    On Linux and OS X:
-
-        .. code-block:: bash
-
-            . rsvenv/bin/activate
-
-4. Run the bootstrap script
+3. Run the bootstrap script
 ***************************
-The next step, which installs required dependencies for the remainder of the process, depends on the two mutually exclusive use cases below. **Remember which use case you select**; many of the following steps vary based on your use case.
+.. warning::
 
-Use case: running the server
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-For the use case of running the server, execute:
+    On Windows using Ubuntu under WSL2: if you see the error message "Docker Desktop not detected..." when running either command below, but you are running the Docker Desktop, then click the gear (settings) icon in Docker Desktop, select Resources then WSL Integration, and make sure the switch next to Ubuntu is turned on.
+
+The next step, which installs required dependencies for the remainder of the process, depends on the two mutually exclusive use cases below. **Remember which use case you select** (either *production* or *development*); many of the following steps vary based on your use case.
+
+Production use case
+^^^^^^^^^^^^^^^^^^^
+If your use case is running the server, execute:
 
 .. code-block:: bash
 
@@ -151,9 +120,9 @@ For the use case of running the server, execute:
 
 **OR**
 
-Use case: in addition to running the server, change the way Runestone works or change/add to the way `interactive exercises <https://pretextbook.org/doc/guide/html/topic-interactive-exercises.html>`_ behave
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-For the developer use case:
+Development use case
+^^^^^^^^^^^^^^^^^^^^
+If, in addition to running the server, your use case is to change the way Runestone works or change/add to the way `interactive exercises <https://pretextbook.org/doc/guide/html/topic-interactive-exercises.html>`_ behave, then:
 
 #.  `Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_ the `RunestoneServer <https://github.com/RunestoneInteractive/RunestoneServer.git>`_, `RunestoneComponents <https://github.com/RunestoneInteractive/RunestoneComponents.git>`_, and `BookServer <https://github.com/RunestoneInteractive/BookServer.git>`_ repositories. If you've already forked these repositories, `fetch the latest updates from these upstream repositories <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork>`_.
 
@@ -163,27 +132,39 @@ For the developer use case:
 
     python3 docker_tools.py init --clone-rs <your Github userid>
 
-.. note::
 
-    On Windows using Ubuntu under WSL2: if you see the error message "Docker Desktop not detected..." but you are running the Docker Desktop, then click the gear (settings) icon in Docker Desktop, select Resources then WSL Integration, and make sure the switch next to Ubuntu is turned on.
+Post-build
+^^^^^^^^^^
+This process may take a few minutes to complete. When it does:
 
-5. Build the necessary containers
+#.  **Reboot your computer** to update your group membership.
+#.  Run the Docker Desktop if using WSL2 on Windows or using OS X.
+#.  Open a terminal.
+#.  **OS X only**: Activate your virtual environment -- at the terminal, execute ``source rsdocker/rsvenv/bin/activate``.
+
+
+4. Build the necessary containers
 *********************************
+
 In the terminal, type:
 
 .. code-block:: bash
 
-    cd RunestoneServer
+    cd rsdocker/RunestoneServer
 
 .. note::
 
-    All future commands should be run in the ``RunestoneServer`` directory unless instructions specify otherwise.
+    All future commands should be run in the ``rsdocker/RunestoneServer`` directory unless instructions specify otherwise.
 
 The next command depends on the use case you chose in the previous step.
 
 Pre-build
 ^^^^^^^^^
-For the use case of running the server, execute:
+.. note:
+
+    The ``docker-tools build`` command offers many additional options for advanced users, viewable by running ``docker-tools build --help``.
+
+For the production use case, execute:
 
     .. code-block:: bash
 
@@ -191,80 +172,72 @@ For the use case of running the server, execute:
 
 **OR**
 
-For the developer use case, execute:
+For the development use case, execute:
 
     .. code-block:: bash
 
         docker-tools build --single-dev --clone-all <your Github userid>
 
-.. note:
 
-    The ``docker-tools build`` command offers many additional options for advanced users, viewable by running ``docker-tools build --help``.
+.. note::
 
-Post-build
-^^^^^^^^^^
-The build will take a **long** time (5-10 minutes in many cases). When this completes:
+    The build will take a **long** time (10-20 minutes in many cases). In particular, the last line (``rm -rf $RUNESTONE_PATH``) may seem to hang, but simply takes a long time to complete.
 
-#.  **Reboot your computer** to update your group membership.
-#.  Run the Docker Desktop if using WSL on Windows or using OS X.
-#.  Open a terminal then ``cd rsvenv``.
-#.  Activate your virtual environment -- see the second step of `create a virtual environment <Create then activate a Python virtual environment>`_.
-#.  ``cd RunestoneServer``.
 
-6. Configuration
-***********************
+5. Configuration
+****************
 
 Most basic configuration can be done via two files you will need to create. These files
 are read every time the server is restarted - to see the effects of any changes you will
 need to stop the containers and restart them.
 
 Environment Variables
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
-For the developer use case, you do not need to modify any of the default environment variables.
+For the development use case, you do not need to modify any of the default environment variables.
 
 **OR**
 
-For the use case of running the server, you will need to modify these variables. To do so, edit the ``.env`` file, which Docker will read automatically as it loads containers. A sample ``.env`` file is provided as ``./.env`` (copied from `docker/.env.prototype <.env.prototype>` on the first build). See comments in the file for details.
+For the production use case, you will need to modify these variables. To do so, edit the ``.env`` file, which Docker will read automatically as it loads containers. A sample ``.env`` file is provided as ``./.env`` (copied from `docker/.env.prototype <.env.prototype>` on the first build). See comments in the file for details.
 
 Python Settings
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^
 
-For the developer use case, you do not need to modify any of the default Python settings.
+For the development use case, you do not need to modify any of the default Python settings.
 
 **OR**
 
-For the use case of running the server, you will need to modify these settings to obtain an HTTPS certificate, send the lost password e-mails, etc. These options will be in the file ``models/1.py`` (which is automatically created on the first build).
+For the production use case, you will need to modify these settings to obtain an HTTPS certificate, send the lost password e-mails, etc. These options will be in the file ``models/1.py`` (which is automatically created on the first build).
 
 .. warning::
 
     You will NOT want to check either ``.env`` or ``models/1.py`` into source control, since these contain passwords. The ``.gitignore`` file is set to ignore both of them.
 
 
-7. Starting the containerized application
+6. Starting the containerized application
 *****************************************
 
 Pre-start
 ^^^^^^^^^
 Once your environment is ready to go, you can use ``docker compose`` to bring the containers up. This command will create four containers to run different parts of the application stack (the Runestone server, redis cache, postgres DB, jobe code testing environment).
 
-For the use case of running the server, execute:
+For the production use case, execute:
 
     .. code-block:: bash
 
         docker compose up -d
 
-    This run the container in the background (detached mode). Use ``docker compose logs --follow`` to view logging data as the container starts up and runs.
+    This runs the container in the background (detached mode). Use ``docker compose logs --follow`` to view logging data as the container starts up and runs; open another terminal to execute instructions from the following steps.
 
 **OR**
 
-For the developer use case, execute:
+For the development use case, execute:
 
     .. code-block:: bash
 
         docker compose up
 
-    This displays logging data from the container in the terminal. To Stop the container, press when ctrl-c.
+    This displays logging data from the container in the terminal. To stop the container, press ctrl-c. Open another terminal to execute the following commands.
 
 
 Post-start
@@ -284,8 +257,8 @@ The ``rsmanage`` command will run many useful commands inside the container for 
 ...and many other things.  Just type ``rsmanage`` for a list of things it can do.  For a list of options just type ``rsmanage`` and the subcommand you want followed by ``--help``; for example, ``rsmanage build --help``.
 
 
-8. Add books
-**************************
+7. Add books
+************
 
 No books are installed by default; you must add books using the following process. To add a book, you need to add its source code to the ``RunestoneServer/books/`` directory. Typically, that means cloning its source code. For example, to add
 `thinkcspy <https://github.com/RunestoneInteractive/thinkcspy>`_:
@@ -318,13 +291,12 @@ The following information applies only *authoring* books using the Runestone.
    If you are running docker on a remote host then make sure to set it to the name of the remote host.
 
 
-9. Add courses
-**************************
+8. Add courses
+**************
 
 To add a course based on a book, run the ``rsmanage addcourse`` script. If you run it just like
 that it will prompt you for all of the necessary details. Probably the **most important** thing
-to point out is that if this is a new book the first time you add it you want to make sure that the
-basecourse and the course-name are the same.  If you are creating your own course but want it
+to point out is that if this is a new book the first time you add it you want to make sure that the basecourse and the course-name are the same.  If you are creating your own course but want it
 based on an existing book then make sure to use the correct base course name.
 
 .. code-block:: bash
@@ -351,13 +323,14 @@ You do not have to restart the server to make use of the course.
     a course with a name like ``thinkcspy`` you will be told that the course name is the same as the book.
 
 
-10. Add a user
-**************************
+9. Add users
+************
 
-To add an initial instructor account to the course you have created, you can either create a new user or add
-an existing user as an instructor to the course.
+To add an initial instructor account to the course you have created, you can either create a new user or add an existing user as an instructor to the course. You may use the web interface or the terminal -- the command-line interface, or CLI -- to do this.
 
-To add a new user, use the ``rsmanage adduser`` subcommand  it asks for what class to add the user to and whether or not
+Web interface: browse to ``https://<your domain name>/runestone/designer/index`` (production use case) or ``https://localhost/runestone/designer/index`` (development use case). Use this web page to create a new course.
+
+CLI: To add a new user, use the ``rsmanage adduser`` subcommand; it asks for what class to add the user to and whether or not
 they should be made an instructor.
 
 .. code-block:: bash
@@ -373,18 +346,7 @@ Or, if you already have an account that you want to add as an instructor to the 
 
 Neither of these will require restarting the server.
 
-Once you have logged in as an instructor, you can bulk add students through the web interface.
-
-It is also possible to use a csv file to add multiple instructors or students as you start
-up the server. However, this process is brittle (any error loading the information results
-in the server entering a restart loop as it fails to load). To do so, make a file named either
-`instructors.csv` or `students.csv` in a folder called `configs` in the ``RunestoneServer/`` folder.
-The format of the csv files is to have one person per line with the format of each line as follows:
-
-    username,email,first_name,last_name,pw,course
-
-Once you have started the server, you may have to remove that file to prevent subsequent restarts
-trying to load the same records and entering a restart loop because the records already exist.
+Once you have logged in as an instructor, you can bulk add students through the web interface. After logging in to your running server as an instructor, browse to the Instructor's Page, then click on the Manage Students tab.
 
 
 Operation
@@ -393,17 +355,18 @@ The containerized application is configured to automatically start as soon as Do
 
 Before using ``docker-tools`` or ``rsmanage``:
 
-#.  Open a terminal then ``cd rsdocker``.
-#.  Activate your virtual environment -- see the second step of `create a virtual environment <Create then activate a Python virtual environment>`_.
-#.  ``cd RunestoneServer``.
+#.  Run the Docker Desktop if using WSL2 on Windows or using OS X.
+#.  Open a terminal.
+#.  **OS X only**: Activate your virtual environment -- at the terminal, execute ``source rsdocker/rsvenv/bin/activate``.
+#.  At the terminal, execute ``cd rsdocker/RunestoneServer``.
 
 
 Other Tips & Tricks
--------------------------------
+-------------------
 
 
 Rebuilding
-***********************
+**********
 
 To re-build an image:
 
@@ -414,7 +377,7 @@ To re-build an image:
     # Actually run the build (add options as desired)
     docker-tools build
 
-To force a rebuild, make sure the containers are `stopped <4. Starting/Stopping>`_, then rerun the build
+To force a rebuild, make sure the containers are stopped by executing ``docker compose stop``, then rerun the build
 command. The build process caches results from previous builds and should complete much more rapidly. However, the
 cache can cause issues if you modify a file that the system is checking for changes. If you need to force a
 complete rebuild, use:
@@ -424,7 +387,7 @@ complete rebuild, use:
     docker-tools build -- --no-cache
 
 Shelling Inside
-**********************************
+***************
 
 You can shell into the container to look around, or otherwise test. When you enter,
 you'll be in the web2py folder, where ``runestone/`` is an application under ``applications/``. From the ``RunestoneServer/`` directory do:
@@ -447,14 +410,14 @@ Data is stored on a Docker containerized application in two distinct places:
 **Anything written to layers after the Docker build process will be lost.** For example, if you shell into the container then ``apt install`` a package, these changes will be lost if the container is stopped, its configuration changed, etc. This is the nature of Docker. See the `docs <https://docs.docker.com/storage/>`__ for more information.
 
 SSH/VNC access
-*********************
+**************
 
 To install a VNC client on Linux, execute ``sudo apt install gvncviewer``. Next, run ``gvncviewer localhost:0 &``. This allows you to open a terminal in the container, see Chrome as Selenium tests run, etc.
 
 Execute ``sudo apt install openssh-server`` to install a SSH server. This allows easy access from VSCode, as well as usual SSH access.
 
-Developer notes
-***********************************************
+Development notes
+*****************
 
 If you make changes to the Runestone Components, you must rebuild the bundle of JavaScript bundle produced by webpack using ``npm run build``, then re-build the book (or page of a book) which uses the component you're editing via a ``runestone build`` or ``pretext build``. The unit tests do this automatically; for development, it's easiest to make changes to the test then re-run the test to guarantee the correct builds are done.
 
@@ -465,7 +428,7 @@ If you make changes to the Runestone server, most changes will be immediately ap
 You can run the unit tests in the container using the ``docker-tools test`` command.
 
 Testing the Entrypoint
-**********************************
+**********************
 
 If you want to test the script, the easiest thing
 to do is add a command to the ``docker compose`` to disable it, and then run commands
@@ -476,7 +439,7 @@ to test the entry point script - since the other containers were started
 with ``docker compose`` everything in them is ready to go.
 
 File Permissions
-**********************************
+****************
 
 File permissions can seem a little strange when you start this container on Linux. Primarily because both
 nginx and Gunicorn run as the ``www-data`` user. So you will suddenly find your files under RunestoneServer
@@ -484,7 +447,7 @@ owned by ``www-data`` . The container's entry point script updates permissions t
 container enough privileges to do your work.
 
 Writing Your Own Book
-**********************************
+*********************
 
 .. note::
 

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -3,8 +3,7 @@ Docker Deployment
 
 .. TODO
 
-    See https://github.com/RunestoneInteractive/RunestoneServer/issues/1973 for ideas on how to improve this still-complex problem.
-
+    See https://github.com/RunestoneInteractive/RunestoneServer/issues/1973 for ideas on how to improve this still-complex problem. See https://github.com/RunestoneInteractive/RunestoneServer/pull/1977 for OS X problems and fixes.
 
 .. note::
 
@@ -41,6 +40,7 @@ OS X
 ^^^^
 Open a Terminal. In the Terminal:
 
+#.  Edit ``/etc/paths``; add ``/opt/homebrew/bin`` as the first line in that file.
 #.  `Install Homebrew <https://brew.sh/#install>`_.
 #.  Execute ``brew install python docker``.
 #.  Run the newly-installed Docker Desktop application.
@@ -54,7 +54,7 @@ Windows
 If running on Windows, either:
 
     `Install Ubuntu on WSL2 <https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-10#1-overview>`_. Next, install then run
-    `Docker Desktop`_; see the note above on the initialization process.
+    `Docker Desktop <https://docs.docker.com/desktop/install/windows-install/>`_; see the note above on the initialization process.
 
     **OR**
 
@@ -140,7 +140,6 @@ This process may take a few minutes to complete. When it does:
 #.  **Reboot your computer** to update your group membership.
 #.  Run the Docker Desktop if using WSL2 on Windows or using OS X.
 #.  Open a terminal.
-#.  **OS X only**: Activate your virtual environment -- at the terminal, execute ``source rsdocker/rsvenv/bin/activate``.
 
 
 4. Build the necessary containers
@@ -273,7 +272,7 @@ After cloning a book, you may need to add it to the database.  Most of the stand
 
     PreTeXt authors, see `Publishing to Runestone Academy <https://pretextbook.org/doc/guide/html/sec-publishing-to-runestone-academy.html>`_.  After that, you can build a pretext book just like building a Runestone book ``rsmanage build --ptx coursename``
 
-The following information applies only *authoring* books using the Runestone. 
+The following information applies only *authoring* books using the Runestone.
 
 .. warning::
 
@@ -357,7 +356,6 @@ Before using ``docker-tools`` or ``rsmanage``:
 
 #.  Run the Docker Desktop if using WSL2 on Windows or using OS X.
 #.  Open a terminal.
-#.  **OS X only**: Activate your virtual environment -- at the terminal, execute ``source rsdocker/rsvenv/bin/activate``.
 #.  At the terminal, execute ``cd rsdocker/RunestoneServer``.
 
 

--- a/docker/docker_tools.py
+++ b/docker/docker_tools.py
@@ -162,19 +162,6 @@ from ci_utils import chdir, env, is_darwin, is_linux, pushd, xqt  # noqa: E402
 
 # Third-party bootstrap
 # ---------------------
-# On OS X, create then activate a venv. Otherwise, the ``docker-tools`` and ``rsmanage`` scripts don't get put in the default path (while on Linux they do) when not in a venv. Rather than require users to manually edit their path, use a venv and require them to activate the venv before running these scripts.
-if is_darwin and not IN_VENV:
-    # If the repo's already cloned, but the venv isn't activated, create it if it doesn't exist.
-    venv_path = (wd / (("../../" if IN_REPO else "") + "rsvenv")).resolve()
-    if not venv_path.is_dir():
-        xqt(f"python3 -m venv {venv_path}")
-    # pip doesn't provide ``activate_this.py`` (Poetry does). For now, ask the user to run this in the created venv.
-    sys.exit(
-        "Phase 1 init complete. Execute:\n"
-        f"  source {venv_path}/bin/activate\n"
-        "then re-run this command to continue to phase 2."
-    )
-
 # This comes after importing ``ci_utils``, since we use that to install click if necessary.
 try:
     import click
@@ -359,7 +346,7 @@ def init(
     # Provide server-related CLIs. While installing this sooner would be great, we can't assume that the prereqs (the downloaded repo) are available.
     check_install(f"{sys.executable} -m pip --version", "python3-pip")
     xqt(
-        # Note: Outside a venv, OS X installs these into a place that's not in the default $PATH, making the scripts ``docker-tools`` and ``rsmanage`` not work unless the user manually adds the path. Add the ``--verbose`` flag to the install commands below to see where the scripts are place on OS X.
+        # Note: Sometimes, OS X installs these into a place that's not in the default $PATH, making the scripts ``docker-tools`` and ``rsmanage`` not work unless the user manually adds the path. Add the ``--verbose`` flag to the install commands below to see where the scripts are placed on OS X.
         f"{sys.executable} -m pip install {pip_user()} -e docker",
         f"{sys.executable} -m pip install {pip_user()} -e rsmanage",
     )
@@ -369,6 +356,7 @@ def init(
         print(
             "\n" + "*" * 80 + "\n"
             "Downloaded the RunestoneServer repo. You must \n"
+            '"cd RunestoneServer" before running this script again.'
         )
     if did_group_add:
         print(

--- a/docker/docker_tools.py
+++ b/docker/docker_tools.py
@@ -285,18 +285,15 @@ def init(
     # Linux only: Ensure the user is in the ``docker`` group. This follows the `Docker docs <https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user>`__. Put this step here, instead of after the Docker install, for people who manually installed Docker but skipped this step.
     if is_linux:
         print("Checking to see if the current user is in the docker group...")
-        if "www-data" not in xqt("groups", capture_output=True, text=True).stdout:
-            if is_darwin:
-                xqt("sudo dscl . append /Groups/docker GroupMembership $USER")
+        if "docker" not in xqt("groups", capture_output=True, text=True).stdout:
+            # Per the `Docker docs <https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user>`_, enable running Docker as a non-root user.
+            #
+            # Ignore errors if the groupadd fails; the group may already exist.
+            xqt('sudo groupadd docker', check=False)
+            xqt('sudo usermod -a -G docker $USER')
 
-            else:
-                # Per the `Docker docs <https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user>`_, enable running Docker as a non-root user.
-                #
-                # Ignore errors if the groupadd fails; the group may already exist.
-                xqt('sudo groupadd docker', check=False)
-                xqt('sudo usermod -a -G docker $USER')
-                # Until group privileges to take effect, use ``sudo`` to run Docker.
-                docker_sudo = True
+            # Until group privileges to take effect, use ``sudo`` to run Docker.
+            docker_sudo = True
             # The group add doesn't take effect until the user logs out then back in. Work around it for now.
             did_group_add = True
 


### PR DESCRIPTION
This puts all the cloned repos in the `rsdocker/` subdirectory.

On OS X, it runs everything in a venv placed in `rsdocker/rsvenv`.

There are also lots of docs fixes and improvements.