### PR TITLE
Sorted the list of instructor in-place inside the admin.html file

### DIFF
--- a/views/admin/admin.html
+++ b/views/admin/admin.html
@@ -188,8 +188,8 @@
             <div class="list-group">
                 <form method="POST" id="removeins" action="Javascript:remove_instructor();">
                     <select size="10" id="instructorlist" name="instructor" class="form-control">
-                        {{ for person in instructors: }}
-                        <option value="{{=person}}">{{ =instructors[person] }}</option>
+                        {{ for person in sorted(list(instructors.values()), key=lambda s: str(s).split(" ")[1]): }}
+                        <option value="{{=person}}">{{ =person }}</option>
                         {{ pass }}
                     </select>
                     <div style="text-align: center">


### PR DESCRIPTION
solved issue #1955  By sorting the instructors' and Ta's names in place based on their last names. 
I assumed that each name is made of a first name and the last name, separated by a space. The way the `instructors` dict is built inside admin.py made me assume this should be valid.