### PR TITLE
Reduce worker count on development deploys

### DIFF
--- a/docker/gunicorn_config/fastapi_config.py
+++ b/docker/gunicorn_config/fastapi_config.py
@@ -33,7 +33,10 @@ if os.environ["BOOK_SERVER_CONFIG"] == "development":
 wsgi_app = "bookserver.main:app"
 
 # `workers <https://docs.gunicorn.org/en/stable/settings.html#workers>`_: The number of worker processes for handling requests. Pick this based on CPU count.
-workers = multiprocessing.cpu_count() * 2 + 1
+if os.environ["BOOK_SERVER_CONFIG"] == "development":
+    workers = 4
+else:
+    workers = multiprocessing.cpu_count() * 2 + 1
 
 # `worker_class <https://docs.gunicorn.org/en/stable/settings.html#worker-class>`_: The type of workers to use. Use `uvicorn's worker class for gunicorn <https://www.uvicorn.org/deployment/#gunicorn>`_.
 worker_class = "uvicorn.workers.UvicornWorker"

--- a/docker/gunicorn_config/web2py_config.py
+++ b/docker/gunicorn_config/web2py_config.py
@@ -32,7 +32,10 @@ chdir = os.environ["WEB2PY_PATH"]
 wsgi_app = "wsgihandler:application"
 
 # `workers <https://docs.gunicorn.org/en/stable/settings.html#workers>`_: The number of worker processes for handling requests. Pick this based on CPU count.
-workers = multiprocessing.cpu_count()
+if os.environ["BOOK_SERVER_CONFIG"] == "development":
+    workers = 4
+else:
+    workers = multiprocessing.cpu_count()
 
 # `bind <https://docs.gunicorn.org/en/stable/settings.html#bind>`_: The socket to bind. This must match the socket nginx sends to.
 bind = "unix:/run/web2py.sock"


### PR DESCRIPTION
Launching large numbers of workers causes issues on high core count machines when developing in WSL